### PR TITLE
[Fix/#10] Nav 폰트 weight 변경

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -10,7 +10,7 @@ const Nav = ({ userName }) => {
             <Link to="/">
               <img src={Logo} alt="logo" className="w-[130px] object-contain" />
             </Link>
-            <div className="text-base text-blue-500 font-extrabold pl-[60px] mt-[3px]">
+            <div className="text-base text-blue-500 font-semibold pl-[60px] mt-[3px]">
               여행하는 즐거움의 발견 유렌카!!
             </div>
           </div>
@@ -19,7 +19,7 @@ const Nav = ({ userName }) => {
             <div className="w-[200px] flex justify-end items-center mr-3">
               <Link to="center">
                 <div className="mx-2 px-1 py-1 hover:px-4 hover:py-2 transition-all ease-in rounded-md hover:shadow-[0_0_5px_1px_rgba(0,0,0,0.2)] hover:text-blue-500">
-                  <span className="text-base font-bold transition-all ease-in">
+                  <span className="text-base font-semibold transition-all ease-in">
                     고객센터
                   </span>
                 </div>


### PR DESCRIPTION

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

폰트의 weight가 적용되지 않는 버그를 수정하고 난 뒤, 이전에 Nav 에서 weight가 달랐지만 인지하고 넘어갔었던 부분이 있다는 것을 발견하였음

## 🥥 Contents

고객센터와 마이페이지 글자의 weight가 달랐던 문제 수정

로고 오른쪽의 소개글 weight 수정

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 적용이 잘 되는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

<img width="1056" alt="스크린샷 2023-09-22 오후 6 52 54" src="https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/7313588a-d8a5-4a9c-8cac-0e8ed0267736">

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #10 

close #10 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
