### PR TITLE
[Feat/#17] 팝업에서 사용할 수 있는 기능들을 구현한 usePopUp 추가

### DIFF
--- a/src/recoil/popUpInfoSelector.js
+++ b/src/recoil/popUpInfoSelector.js
@@ -1,0 +1,12 @@
+import { atom, atomFamily } from "recoil";
+
+export const popUpInfoSelector = atomFamily({
+  key: "popUpInfoSelector",
+  default: (popUpKey) =>
+    atom({
+      key: `popUpInfoSelector/${popUpKey}`,
+      default: {
+        isShow: false,
+      },
+    }),
+});

--- a/src/utils/popUp/usePopUp.js
+++ b/src/utils/popUp/usePopUp.js
@@ -1,0 +1,32 @@
+import { popUpInfoSelector } from "recoil/popUpInfoSelector";
+import { useEffect, useState, useRef } from "react";
+import { useRecoilState } from "recoil";
+
+export const usePopUp = function (popUpKey, enableScroll = false) {
+  const [popUpInfo, setPopUpInfo] = useRecoilState(popUpInfoSelector(popUpKey));
+
+  const popUp = {};
+
+  // 팝업 스크롤 방지
+  const openPopUp = () => {
+    document.body.style.overflow = "hidden";
+  };
+
+  // 스크롤 정상화
+  const closePopUp = () => {
+    document.body.style.overflow = "unset";
+  };
+
+  popUp.toggle = function () {
+    if (!enableScroll) {
+      popUp.isClicked ? closePopUp() : openPopUp();
+    }
+
+    setPopUpInfo({ ...popUpInfo, isShow: !popUpInfo.isShow });
+  };
+
+  popUp.isShow = popUpInfo.isShow;
+  popUp.isClicked = popUpInfo.isShow;
+
+  return popUp;
+};


### PR DESCRIPTION


<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

공용으로 사용할 수 있는 기능이나 함수들을 모아둔 utils 폴더를 생성하고
팝업에서 사용할 수 있는 기능들을 구현한 usePopUp 추가

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

### popUp 정보를 가지는 아톰을 반환하는 atomFamily 추가
``` js
import { atom, atomFamily } from "recoil";

export const popUpInfoSelector = atomFamily({
  key: "popUpInfoSelector",
  default: (popUpKey) =>
    atom({
      key: `popUpInfoSelector/${popUpKey}`,
      default: {
        isShow: false,
      },
    }),
});
```

- key를 외부에서 받아서 원하는 아톰을 만드는 기능을 한다.

### usePopUp 구현
``` js
export const usePopUp = function (popUpKey, enableScroll = false) {
  const [popUpInfo, setPopUpInfo] = useRecoilState(popUpInfoSelector(popUpKey));

  const popUp = {};

  // 팝업 스크롤 방지
  const openPopUp = () => {
    document.body.style.overflow = "hidden";
  };

  // 스크롤 정상화
  const closePopUp = () => {
    document.body.style.overflow = "unset";
  };

  popUp.toggle = function () {
    if (!enableScroll) {
      popUp.isClicked ? closePopUp() : openPopUp();
    }

    setPopUpInfo({ ...popUpInfo, isShow: !popUpInfo.isShow });
  };

  popUp.isShow = popUpInfo.isShow;
  popUp.isClicked = popUpInfo.isShow;

  return popUp;
};
```

- popUp에 대한 key를 받으면 popUp에 대한 정보를 recoil 전역변수에 담아서 반환하는 커스텀 훅 생성
- popUp이 on 이면 스크롤을 방지하고 off이면 스크롤이 가능하게 만드는 기능 추가
- 상태를 쉽게 바꿀 수 있게 toggle 추가

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing


<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #17 

close #17 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

[recoil 공식 홈페이지](https://recoiljs.org/ko/docs/api-reference/utils/atomFamily/)
<!-- 자신이 참조한 정보의 출처를 적는다. -->

<br>