### PR TITLE
[Feat/#29] 마이페이지 사용자 이용 내역 구현

### DIFF
--- a/src/components/CarCard.js
+++ b/src/components/CarCard.js
@@ -1,0 +1,49 @@
+import Car from "assets/Car.png";
+import { useRecoilValue } from "recoil";
+import { carAtom } from "recoil/carAtom";
+import { Chip } from "@material-tailwind/react";
+
+const CarCard = () => {
+  const carInfo = useRecoilValue(carAtom); // 차량 정보
+  return (
+    <div className="w-[270px] h-[376px] rounded-2xl bg-white mt-8">
+      {/* 차량 사진 */}
+      <img
+        src={Car}
+        alt="차량 사진"
+        className="object-cover h-[164px] w-full rounded-t-2xl"
+      ></img>
+      {/* 차량 해쉬태그 */}
+      <div className="flex flex-wrap items-center justify-center mt-2">
+        <Chip
+          value={`# ${carInfo.car}`}
+          className="text-[13px] font-semibold text-white bg-blue-500 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+        />
+        <Chip
+          value={`# ${carInfo.number}`}
+          className="text-[13px] font-semibold text-white bg-blue-400 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+        />
+        <Chip
+          value={`# ${carInfo.odo}km`}
+          className="text-[13px] font-semibold text-blue-900 bg-blue-300 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+        />
+        <Chip
+          value={`# ${carInfo.price / 10000}만원대`}
+          className="text-[13px] font-semibold text-blue-900 bg-blue-100 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+        />
+      </div>
+      {/* 차량 이름 */}
+      <div className="pl-4 mt-4 text-2xl font-extrabold">GRANDEUR HG</div>
+      {/* 차량 가격 */}
+      <div className="pl-4 mt-4 text-xl font-bold">
+        <span className="line-through text-slate-500">{`₩${
+          carInfo.price * 1.3
+        }`}</span>
+        <span className="ml-2 text-red-500">-30%</span>
+      </div>
+      <div className="flex justify-end pr-4 mt-2 font-extrabold text-[28px] text-blue-500">{`₩${carInfo.price}`}</div>
+    </div>
+  );
+};
+
+export default CarCard;

--- a/src/components/CarCard.js
+++ b/src/components/CarCard.js
@@ -6,7 +6,7 @@ import { Chip } from "@material-tailwind/react";
 const CarCard = () => {
   const carInfo = useRecoilValue(carAtom); // 차량 정보
   return (
-    <div className="w-[270px] h-[376px] rounded-2xl bg-white mt-8">
+    <div className="w-[270px] h-[376px] rounded-2xl bg-white mt-8 hover:shadow-figma">
       {/* 차량 사진 */}
       <img
         src={Car}
@@ -17,23 +17,23 @@ const CarCard = () => {
       <div className="flex flex-wrap items-center justify-center mt-2">
         <Chip
           value={`# ${carInfo.car}`}
-          className="text-[13px] font-semibold text-white bg-blue-500 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+          className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-500"
         />
         <Chip
           value={`# ${carInfo.number}`}
-          className="text-[13px] font-semibold text-white bg-blue-400 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+          className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-400"
         />
         <Chip
           value={`# ${carInfo.odo}km`}
-          className="text-[13px] font-semibold text-blue-900 bg-blue-300 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+          className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-300 text-blue-900"
         />
         <Chip
           value={`# ${carInfo.price / 10000}만원대`}
-          className="text-[13px] font-semibold text-blue-900 bg-blue-100 w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1"
+          className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-200 text-blue-900"
         />
       </div>
       {/* 차량 이름 */}
-      <div className="pl-4 mt-4 text-2xl font-extrabold">GRANDEUR HG</div>
+      <div className="pl-4 mt-4 text-2xl font-extrabold">{carInfo.car}</div>
       {/* 차량 가격 */}
       <div className="pl-4 mt-4 text-xl font-bold">
         <span className="line-through text-slate-500">{`₩${

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,6 +1,7 @@
 import Reservation from "./Reservation";
 import UserInfo from "./UserInfo";
 import PreferOption from "./PreferOption";
+import Record from "./Record";
 import License from "./License";
 import Account from "./Account";
 import Alert from "popUp/Alert";
@@ -21,6 +22,8 @@ const MyPage = () => {
         <UserInfo />
         {/* 사용자 선호 차량 옵션 */}
         <PreferOption />
+        {/* 사용자 사용 내역 */}
+        <Record />
         {/* 사용자 면허 정보 */}
         <License />
         {/* 사용자 계정 관리 */}

--- a/src/pages/MyPage/Record.js
+++ b/src/pages/MyPage/Record.js
@@ -1,0 +1,53 @@
+import CarCard from "components/CarCard";
+import { useRecoilValue } from "recoil";
+import { userAtom } from "recoil/userAtom";
+
+const Record = () => {
+  const userInfo = useRecoilValue(userAtom); // 사용자 정보
+  return (
+    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+      {/* 타이틀 */}
+      <div className="w-[1010px] h-[70px] flex justify-between items-center">
+        <span className="text-blue-800 text-[45px] font-extrabold">
+          내역 조회
+        </span>
+      </div>
+      {/* 포인트 사용 내역 */}
+      <div className="w-[1010px] h-40 bg-white rounded-2xl flex items-center justify-between px-8 mt-7">
+        <div className="flex flex-col justify-between h-24 text-2xl font-bold w-fit">
+          <div className="text-slate-400">포인트 사용 내역</div>
+          <div className="flex items-center justify-between w-full text-2xl font-bold">
+            현재 포인트 : {userInfo.point}
+          </div>
+        </div>
+        <button className="w-56 h-16 text-2xl font-bold bg-sky-200 rounded-2xl">
+          사용 내역 확인
+        </button>
+      </div>
+      {/* 예약 내역 조회 */}
+      <div className="w-[1010px] h-40 bg-white rounded-2xl flex items-center px-8 mt-7">
+        <div className="flex items-center justify-between w-full h-24 text-2xl font-bold">
+          <div>예약 내역 조회</div>
+          <button className="w-56 h-16 text-2xl font-bold bg-sky-200 rounded-2xl">
+            예약 내역 확인
+          </button>
+        </div>
+      </div>
+      {/* 최근 본 차량 조회 */}
+      <div className="w-[1010px] bg-white rounded-2xl flex items-center px-8 py-8 mt-7">
+        <div className="flex flex-col justify-between w-full text-2xl font-bold">
+          최근 본 차량 조회
+          <div className="flex flex-wrap items-center justify-between w-full px-8 pb-8 mt-4 bg-blue-100 rounded-2xl">
+            {Array(6)
+              .fill(0)
+              .map(() => {
+                return <CarCard />;
+              })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Record;

--- a/src/pages/MyPage/Record.js
+++ b/src/pages/MyPage/Record.js
@@ -40,8 +40,8 @@ const Record = () => {
           <div className="flex flex-wrap items-center justify-between w-full px-8 pb-8 mt-4 bg-blue-100 rounded-2xl">
             {Array(6)
               .fill(0)
-              .map(() => {
-                return <CarCard />;
+              .map((v, i) => {
+                return <CarCard key={i} />;
               })}
           </div>
         </div>

--- a/src/recoil/carAtom.js
+++ b/src/recoil/carAtom.js
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+
+export const carAtom = atom({
+  key: "carAtom",
+  default: {
+    car: "그랜저 HG",
+    number: "12삼 4567",
+    odo: 50000,
+    price: 200000,
+  },
+});

--- a/src/recoil/userAtom.js
+++ b/src/recoil/userAtom.js
@@ -19,6 +19,7 @@ export const userAtom = atom({
       oilTypes: [false, true, false, true],
       transmissions: [true, false],
     },
+    point: 10000,
   },
 });
 


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->
- 포인트 사용 내역 구현
- 예약 내역 조회 구현
- 최근 본 차량 조회 및 카드뷰 구현

## 🥥 Contents
### 포인트 사용 내역
```javascript
// Record.js
{/* 포인트 사용 내역 */}
<div className="w-[1010px] h-40 bg-white rounded-2xl flex items-center justify-between px-8 mt-7">
  <div className="flex flex-col justify-between h-24 text-2xl font-bold w-fit">
    <div className="text-slate-400">포인트 사용 내역</div>
    <div className="flex items-center justify-between w-full text-2xl font-bold">
      현재 포인트 : {userInfo.point}
    </div>
  </div>
  <button className="w-56 h-16 text-2xl font-bold bg-sky-200 rounded-2xl">
    사용 내역 확인
  </button>
</div>

// userAtom.js
...
},
point: 10000,
```
포인트 사용 내역의 경우 현재 사용자가 보유하고 있는 포인트를 확인할 수 있다. 따라서, 기존의 사용자의 정보들을 저장하던 userAtom 에 point 를 추가해주었고 해당 정보를 보여주게된다.
<br>

### 예약 내역 조회
```javascript
// Record.js
{/* 예약 내역 조회 */}
<div className="w-[1010px] h-40 bg-white rounded-2xl flex items-center px-8 mt-7">
  <div className="flex items-center justify-between w-full h-24 text-2xl font-bold">
    <div>예약 내역 조회</div>
    <button className="w-56 h-16 text-2xl font-bold bg-sky-200 rounded-2xl">
      예약 내역 확인
    </button>
  </div>
</div>
```
현재까지는 세부 내역들을 확인할 수 있는 팝업을 구현하기 전이기에 단순히 멘트와 버튼만이 존재한다.
<br>

### 최근 본 차량 조회
```javascript
// carAtom.js
export const carAtom = atom({
  key: "carAtom",
  default: {
    car: "그랜저 HG",
    number: "12삼 4567",
    odo: 50000,
    price: 200000,
  },
});

// CarCard.js
{/* 차량 해쉬태그 */}
<div className="flex flex-wrap items-center justify-center mt-2">
  <Chip
    value={`# ${carInfo.car}`}
    className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-500"
  />
  <Chip
    value={`# ${carInfo.number}`}
    className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-400"
  />
...

```
최근 본 차량 조회에서는 사용자가 가장 최근에 조회했었던 최대 6대의 차량에 대한 정보들이 담긴 카드뷰를 확인할 수 있다. 그래서 카드뷰 역할을 할 CarCard 컴포넌트와 차량의 정보들을 저장할 carAtom 을 추가로 구현하였다.
```javascript
// components/CarCard.js
<div className="w-[270px] h-[376px] rounded-2xl bg-white mt-8 hover:shadow-figma">
...
```
카드뷰의 경우 선택이됐다는 것을 시각적으로 보여주기 위해서 hover 상태일 때 그림자를 주도록 구현되었다. 또한, 해당 카드뷰 컴포넌트의 경우 마이페이지 뿐만 아니라 여러 곳에서 사용이 되기에 공용 컴포넌트들을 저장하는 components 폴더에 구현되어있다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 사용자 보유 포인트가 정상적으로 보여지는지 확인
- [x] 카드뷰 hover 가 정상적으로 적용되었는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 포인트 사용 내역
![point](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/61669700-4965-4194-879f-197d3221c44d)
<br>

### 예약 내역 조회
![reservation_record](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/f1940ab4-42b5-4a8c-869e-9f93953df53e)
<br>

### 최근 본 차량 조회
![mypagecard_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/e4660ee9-6680-4205-9032-3077f771c363)
<br>

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #29 

close #29 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference
Material-Tailwind Chip : https://www.material-tailwind.com/docs/react/chip
<!-- 자신이 참조한 정보의 출처를 적는다. -->
