### PR TITLE
[Fix/#43] 마이페이지 모든 컴포넌트 그림자 추가

### DIFF
--- a/src/pages/MyPage/Account.js
+++ b/src/pages/MyPage/Account.js
@@ -3,7 +3,7 @@ import { usePopUp } from "utils/usePopUp";
 const Account = () => {
   const popUpInfo = usePopUp("MyPage/Quit"); // 팝업 제어
   return (
-    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
       {/* 타이틀 */}
       <div className="w-[1010px] h-[70px] flex justify-between items-center">
         <span className="text-blue-800 text-[45px] font-extrabold">

--- a/src/pages/MyPage/License.js
+++ b/src/pages/MyPage/License.js
@@ -11,7 +11,7 @@ const License = () => {
     expire: "만료 일자",
   });
   return (
-    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
       {/* 타이틀 */}
       <div className="w-[1010px] h-[70px] flex justify-between items-center">
         <span className="text-blue-800 text-[45px] font-extrabold">

--- a/src/pages/MyPage/PreferOption.js
+++ b/src/pages/MyPage/PreferOption.js
@@ -27,7 +27,7 @@ const PreferOption = () => {
     return newPrefer;
   };
   return (
-    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
       {/* 타이틀 */}
       <div className="w-[1010px] h-[70px] flex justify-between items-center">
         <span className="text-blue-800 text-[45px] font-extrabold">

--- a/src/pages/MyPage/Record.js
+++ b/src/pages/MyPage/Record.js
@@ -8,7 +8,7 @@ const Record = () => {
   const popUpPoint = usePopUp("MyPage/Point"); // Point 팝업 제어
   const popUpResv = usePopUp("MyPage/Resv"); // Resv 팝업 제어
   return (
-    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+    <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
       {/* 타이틀 */}
       <div className="w-[1010px] h-[70px] flex justify-between items-center">
         <span className="text-blue-800 text-[45px] font-extrabold">

--- a/src/pages/MyPage/Reservation.js
+++ b/src/pages/MyPage/Reservation.js
@@ -30,7 +30,7 @@ const Reservation = () => {
   ]);
   return (
     <>
-      <div className="flex flex-col items-center w-full py-4 bg-sky-50 rounded-2xl ">
+      <div className="flex flex-col items-center w-full py-4 bg-sky-50 rounded-2xl shadow-figma">
         {/* 멘트 */}
         <span className="text-black text-[30px] font-bold">
           <span className="text-amber-400 ">{userInfo.name}</span>님이 예약하신

--- a/src/pages/MyPage/UserInfo.js
+++ b/src/pages/MyPage/UserInfo.js
@@ -9,7 +9,7 @@ const UserInfo = () => {
   let [isChanging, setIsChanging] = useState(true); // 닉네임 변경 상태
   return (
     <>
-      <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl">
+      <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
         {/* 타이틀 */}
         <div className="w-[1010px] h-[70px] flex justify-between items-center">
           <span className="text-blue-800 text-[45px] font-extrabold">


### PR DESCRIPTION
각 컨텐츠별 최상위 컴포넌트들에 그림자 추가
 - 최상위 부모 태그에 shadow-figma 추가

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->
마이페이지의 모든 컴포넌트들에 그림자를 추가

## 🥥 Contents
### 그림자 추가
```javascript
// Reservation.js, Userinfo.js, PreferOption.js, Record.js, License.js, Account.js
<div className="flex flex-col items-center w-full py-4 bg-sky-50 rounded-2xl shadow-figma">
  {/* 멘트 */}
...

```
마이페이지에 보여지는 컨텐츠 별로 최상위 컴포넌트의 최상위 태그에 "shadow-figma" 를 적용해주었다.
<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 그림자가 제대로 적용되었는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 모든 컴포넌트 그림자 적용
![mypage-shadow_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/7929629f-dff3-457a-969e-30eb07844b4f)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #43 

close #43 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
