### PR TITLE
[Fix/#55] 예약 페이지 파인더 추가

### DIFF
--- a/src/components/Finder.js
+++ b/src/components/Finder.js
@@ -5,9 +5,9 @@ import { useRecoilState } from "recoil";
 import { finderAtom } from "recoil/finderAtom";
 import { usePopUp } from "utils/usePopUp";
 
-const Finder = () => {
-  const storePopUp = usePopUp("Home/SelectStore");
-  const dateTimePopUp = usePopUp("Home/SelectDateTime");
+const Finder = ({ storePopUp, dateTimePopUp }) => {
+  // const storePopUp = usePopUp("Home/SelectStore");
+  // const dateTimePopUp = usePopUp("Home/SelectDateTime");
 
   const [finderInfo, setFinderInfo] = useRecoilState(finderAtom);
 

--- a/src/pages/Notice/Notice.js
+++ b/src/pages/Notice/Notice.js
@@ -8,8 +8,8 @@ import { useRecoilValue } from "recoil";
 import { finderAtom } from "recoil/finderAtom";
 
 const Notice = () => {
-  const storePopUp = usePopUp("Home/SelectStore"); // 지점 선택 팝업
-  const dateTimePopUp = usePopUp("Home/SelectDateTime"); // 날짜, 시간 선택 팝업
+  const storePopUp = usePopUp("Notice/SelectStore"); // 지점 선택 팝업
+  const dateTimePopUp = usePopUp("Notice/SelectDateTime"); // 날짜, 시간 선택 팝업
   const notices = useRecoilValue(noticeAtom); // 공지사항 정보
   const finderInfo = useRecoilValue(finderAtom); // 지점, 날짜, 시간 정보
   return (

--- a/src/pages/Reservation/Reservation.js
+++ b/src/pages/Reservation/Reservation.js
@@ -7,11 +7,21 @@ import Insurance from "./Insurance";
 import Drivers from "./Drivers";
 import Point from "./Point";
 import Final from "./Final";
+import SelectDateTime from "popUp/SelectDateTime";
+import SelectStore from "popUp/SelectStore";
+import Finder from "components/Finder";
+import { usePopUp } from "utils/usePopUp";
 
 const Reservation = () => {
+  const storePopUp = usePopUp("Reservation/SelectStore"); // 지점 선택 팝업
+  const dateTimePopUp = usePopUp("Reservation/SelectDateTime"); // 날짜, 시간 선택 팝업
   return (
     <>
-      <div className="w-[1140px] mx-auto mt-[176px]">
+      {/* 렌트 날짜, 지점 선택 컴포넌트 */}
+      <div className="w-[860px] h-[70px] rounded-2xl shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] mt-20 mx-auto bg-white flex items-center justify-between z-10">
+        <Finder storePopUp={storePopUp} dateTimePopUp={dateTimePopUp} />
+      </div>
+      <div className="w-[1140px] mx-auto mt-10">
         {/* 차량 기본 정보 */}
         <DefaultInfo />
         {/* 차량 상세 정보 */}
@@ -31,6 +41,13 @@ const Reservation = () => {
         {/* 최종 결제 */}
         <Final />
       </div>
+      {/* 팝업 구역 */}
+      {storePopUp.isClicked ? (
+        <SelectStore popUpInfo={storePopUp} />
+      ) : undefined}
+      {dateTimePopUp.isClicked ? (
+        <SelectDateTime popUpInfo={dateTimePopUp} />
+      ) : undefined}
     </>
   );
 };

--- a/src/popUp/SelectDateTime.js
+++ b/src/popUp/SelectDateTime.js
@@ -26,9 +26,7 @@ function validationTime(time) {
   return true;
 }
 
-const SelectDateTime = () => {
-  const popUpInfo = usePopUp("Home/SelectDateTime");
-
+const SelectDateTime = ({ popUpInfo }) => {
   const [rclFinderDateTime, setRclFinderDateTime] = useRecoilState(
     finderDateTimeSelector
   );

--- a/src/popUp/SelectStore.js
+++ b/src/popUp/SelectStore.js
@@ -6,9 +6,7 @@ import { useRecoilState } from "recoil";
 import { storeAtom } from "recoil/storeAtom";
 import { finderProvinceSelector, finderStoreSelector } from "recoil/finderAtom";
 
-const SelectStore = () => {
-  const popUpInfo = usePopUp("Home/SelectStore");
-
+const SelectStore = ({ popUpInfo }) => {
   const [selectedProvince, setSelectedProvince] = useState("");
 
   const [rclStoreInfo, setRclStoreInfo] = useRecoilState(storeAtom);


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

- 예약 페이지 파인더 추가
- 공지사항 파인더 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 예약 페이지 파인더 추가
```javascript
// Reservation.js
const storePopUp = usePopUp("Reservation/SelectStore"); // 지점 선택 팝업
const dateTimePopUp = usePopUp("Reservation/SelectDateTime"); // 날짜, 시간 선택 팝업

...

{/* 팝업 구역 */}
{storePopUp.isClicked ? (
  <SelectStore popUpInfo={storePopUp} />
) : undefined}
{dateTimePopUp.isClicked ? (
  <SelectDateTime popUpInfo={dateTimePopUp} />
) : undefined}
```
공용 컴포넌트화된 파인더를 예약 페이지의 상단에 추가해주었다. 예약 페이지의 파인더임을 알려주기 위해 또한, 기존의 공지사항에 추가했던 파인더에 key 값이 그대로 Home 이었던 것을 Notice 로 수정해주었다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 파인더가 제대로 동작하는지 확인 

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 예약페이지 파인더
![reservationfinder_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/7ba44fa3-63f8-4f99-9408-a2d800845b28)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #55 

close #55 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
