### PR TITLE
[Feat/#54] 공지사항 상세보기 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import Reservation from "pages/Reservation/Reservation";
 import CarSearch from "pages/CarSearch/CarSearch";
 import Auth from "pages/Auth/Auth";
 import Notice from "pages/Notice/Notice";
-
+import NoticeDetail from "pages/NoticeDetail/NoticeDetail";
 
 function App() {
   /* 
@@ -27,6 +27,7 @@ function App() {
         <Route path="/carsearch" element={<CarSearch />}></Route>
         <Route path="/auth" element={<Auth />}></Route>
         <Route path="/notice" element={<Notice />}></Route>
+        <Route path="/noticedetail" element={<NoticeDetail />}></Route>
       </Routes>
     </>
   );

--- a/src/pages/NoticeDetail/NoticeDetail.js
+++ b/src/pages/NoticeDetail/NoticeDetail.js
@@ -1,0 +1,64 @@
+import dayjs from "dayjs";
+import { useRecoilValue } from "recoil";
+import { MdOutlineArrowBack } from "react-icons/md";
+import { noticeAtom } from "recoil/noticeAtom";
+import { finderAtom } from "recoil/finderAtom";
+import { useState } from "react";
+
+const NoticeDetail = () => {
+  const noticeInfo = useRecoilValue(noticeAtom)[0]; // 공지사항 정보
+  const store = useRecoilValue(finderAtom).store; // 지점
+  // 남은 날짜 계산
+  const [leftDate, setLeftDate] = useState(
+    dayjs().diff(dayjs(noticeInfo.endDate), "day")
+  );
+  return (
+    <>
+      <div className="w-[1140px] mx-auto mt-[120px]">
+        {/* 뒤로 가기 */}
+        <div className="flex">
+          <MdOutlineArrowBack className="text-4xl font-bold text-black" />
+          <span className="ml-4 text-4xl font-bold text-indigo-900">
+            리스트로 돌아가기
+          </span>
+        </div>
+        <div className="w-[1100px] h-[307px] rounded-2xl bg-sky-50 mx-auto mt-12 shadow-figma flex flex-col justify-between px-8 py-10">
+          {/* 공지사항 제목 */}
+          <span className="text-4xl font-extrabold text-blue-900">
+            {noticeInfo.title}
+          </span>
+          {/* 지점 */}
+          <span className="text-3xl font-bold text-blue-600">{store}</span>
+          {/* 이벤트 기간 & 디데이 */}
+          <span className="text-3xl font-semibold text-gray-600">
+            {dayjs(noticeInfo.startDate).format("YY년 MM월 DD일")} ~{" "}
+            {dayjs(noticeInfo.endDate).format("YY년 MM월 DD일")}
+            <span className="ml-12 text-red-500">
+              {leftDate > 0
+                ? `${leftDate}일 남았어요!`
+                : leftDate === 0
+                ? "오늘까지에요!!"
+                : `종료된 이벤트에요`}
+            </span>
+          </span>
+          {/* 최종 작성일 */}
+          <span className="text-3xl font-semibold text-blue-600">
+            최종 작성일 {dayjs(noticeInfo.recentEdit).format("YY년 MM월 DD일")}
+          </span>
+        </div>
+        {/* 공지사항 사진 */}
+        <img
+          src="https://thecatapi.com/api/images/get?format=src&type=gif"
+          alt="공지사항 사진"
+          className="w-[1100px] h-[500px] mx-auto mt-4 rounded-2xl"
+        ></img>
+        {/* 본문 내용 */}
+        <p className="w-[1100px] mx-auto mt-4 mb-40 text-3xl font-normal">
+          {noticeInfo.content}
+        </p>
+      </div>
+    </>
+  );
+};
+
+export default NoticeDetail;


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
공지사항 상세보기 페이지 구현
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 공지사항 상세보기
```javascript
// NoticeDetail.js
{/* 공지사항 제목 */}
<span ...>{noticeInfo.title}</span>
// 제목, 지점 등의 공지사항을 구성하는 내용들
...

{/* 이벤트 기간 & 디데이 */}
<span className="text-3xl font-semibold text-gray-600">
  {dayjs(noticeInfo.startDate).format("YY년 MM월 DD일")} ~{" "}
  {dayjs(noticeInfo.endDate).format("YY년 MM월 DD일")}
  <span className="ml-12 text-red-500">
    {leftDate > 0
      ? `${leftDate}일 남았어요!`
      : leftDate === 0
      ? "오늘까지에요!!"
      : `종료된 이벤트에요`}
  </span>
</span>
```
공지사항 상세보기의 경우 해당 정보를 보여주던 공지사항 카드와 보여주는 내용들이 모두 동일하다. 그래서 보여지는 것에 있어서의 변화만 필요하다. 이벤트 기간 날짜 포맷 변형과 디데이를 계산하여 보여주는 것 역시 공지사항 카드와 모두 동일하다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing
- [x] 날짜 포맷과 디데이가 제대로 보여지는지 확인
- [x] 모든 내용들이 포함되어있는지 확인  

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 공지사항 상세보기 페이지
![noticedetail_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/6dc034a2-d8c2-42da-9cde-ad7ca1245785)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #54 

close #54 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
