### PR TITLE
[Fix/#59] 공지사항 리스트 페이지 파인더 삭제

### DIFF
--- a/src/pages/Notice/Notice.js
+++ b/src/pages/Notice/Notice.js
@@ -1,43 +1,34 @@
-import Finder from "components/Finder";
-import SelectDateTime from "popUp/SelectDateTime";
-import SelectStore from "popUp/SelectStore";
 import NoticeCard from "./NoticeCard";
-import { usePopUp } from "utils/usePopUp";
 import { noticeAtom } from "recoil/noticeAtom";
 import { useRecoilValue } from "recoil";
 import { finderAtom } from "recoil/finderAtom";
+import { MdOutlineArrowBack } from "react-icons/md";
 
 const Notice = () => {
-  const storePopUp = usePopUp("Notice/SelectStore"); // 지점 선택 팝업
-  const dateTimePopUp = usePopUp("Notice/SelectDateTime"); // 날짜, 시간 선택 팝업
   const notices = useRecoilValue(noticeAtom); // 공지사항 정보
   const finderInfo = useRecoilValue(finderAtom); // 지점, 날짜, 시간 정보
   return (
     <>
-      {/* 렌트 날짜, 지점 선택 컴포넌트 */}
-      <div className="w-[860px] h-[70px] rounded-2xl shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] mt-20 mx-auto bg-white flex items-center justify-between z-10">
-        <Finder storePopUp={storePopUp} dateTimePopUp={dateTimePopUp} />
-      </div>
-      <div className="w-[1140px] mx-auto mt-10">
+      <div className="w-[1140px] mx-auto mt-[120px]">
+        {/* 뒤로 가기 */}
+        <div className="flex">
+          <MdOutlineArrowBack className="text-4xl font-bold text-black" />
+          <span className="ml-4 text-4xl font-bold text-indigo-900">
+            뒤로 가기
+          </span>
+        </div>
         {/* 지점 */}
-        <p className="text-[40px] font-extrabold">공지사항</p>
+        <p className="text-[40px] font-extrabold mt-10">공지사항</p>
         <p className="text-[30px] font-bold text-blue-600 mt-4">
           {finderInfo.store}
         </p>
         {/* 공지사항 리스트 */}
         <div className="grid w-full grid-cols-3 mt-4 gap-y-4">
           {notices.map((v, i) => {
-            return <NoticeCard noticeInfo={v} />;
+            return <NoticeCard key={i} noticeInfo={v} />;
           })}
         </div>
       </div>
-      {/* 팝업 구역 */}
-      {storePopUp.isClicked ? (
-        <SelectStore popUpInfo={storePopUp} />
-      ) : undefined}
-      {dateTimePopUp.isClicked ? (
-        <SelectDateTime popUpInfo={dateTimePopUp} />
-      ) : undefined}
     </>
   );
 };


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
- 공지사항 리스트 페이지 파인더 삭제
- 뒤로 가기 버튼 추가
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 파인더 삭제
공지사항 리스트 페이지에서 파인더가 필요없다고 판단되어 삭제하였음.

### 뒤로 가기 버튼 추가
```javascript
// Notice.js
{/* 뒤로 가기 */}
<div className="flex">
  <MdOutlineArrowBack className="text-4xl font-bold text-black" />
  <span className="ml-4 text-4xl font-bold text-indigo-900">
    뒤로 가기
  </span>
</div>
```
파인더가 삭제되면서 검색된 차량 리스트를 볼 수 있는 페이지로 넘어갈 트리거가 필요하게 되어서 뒤로 가기 버튼을 추가하였다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing
- [x] 파인더 삭제와 뒤로 가기 버튼 추가 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 파인더 삭제 & 뒤로 가기 버튼 추가
![noticefinderremove](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/67137587-9123-4430-a1cf-d3b69592f6c4)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #59 

close #59 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
