### PR TITLE
[Fix/#71] 예약 페이지 차량 상세 정보 차량 크기 추가

### DIFF
--- a/src/pages/Reservation/DetailInfo.js
+++ b/src/pages/Reservation/DetailInfo.js
@@ -9,6 +9,7 @@ import {
   MdSettings,
   MdTag,
   MdOutlineFlag,
+  MdPhotoSizeSelectSmall,
 } from "react-icons/md";
 
 const DetailInfo = () => {
@@ -22,6 +23,7 @@ const DetailInfo = () => {
     transmission: "구동기",
     brand: "브랜드",
     domestic: "국산/외제",
+    size: "크기",
   });
   const [iconList, setIconList] = useState([
     // 아이콘
@@ -32,6 +34,7 @@ const DetailInfo = () => {
     <MdSettings className="text-[60px]" />,
     <MdTag className="text-[60px]" />,
     <MdOutlineFlag className="text-[60px]" />,
+    <MdPhotoSizeSelectSmall className="text-[60px]" />,
   ]);
   return (
     <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">

--- a/src/recoil/carAtom.js
+++ b/src/recoil/carAtom.js
@@ -14,6 +14,7 @@ export const carAtom = atom({
     transmission: "자동",
     brand: "현대",
     domestic: "국산",
+    size: "중형",
     repair: [
       {
         date: "2022.05.07",


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
예약 페이지의 차량 상세 정보에서 차량 크기 항목이 누락된 것을 확인하여 추가
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 차량 크기 추가
```javscript
// DetailInfo.js
const [titles, setTitles] = useState({
  // 제목
  ...
  size: "크기",
});
```
기존의 항목 리스트에서 차량 크기를 추가해주었다.
```javascript
// carAtom.js
default: {
  ...
  size: "중형",
  ...
```
기존에 특정 차량의 정보를 저장하던 carAtom 에도 누락되어있던 크기 항목인 size 를 추가해주었다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 차량 크기 정보 반영되었는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 차량 크기
![addcarsize](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/d77549ec-14d5-4087-8698-c6ab152bdd6f)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #71 

close #71 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
