### PR TITLE
[Feat/#100] carousel api 연결

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Feat/#100-carousel-api-link
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Feat/#100-carousel-api-link
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/api/carSearchAxios.js
+++ b/src/api/carSearchAxios.js
@@ -1,0 +1,15 @@
+import api from "./interceptors";
+
+export const getNoticeList = (payload) => {
+  const params = new URLSearchParams();
+
+  params.append("province", payload.province);
+  params.append("branchName", payload.store);
+  params.append("count", payload.count);
+
+  return api({
+    url: "/branches/notices",
+    method: "get",
+    params: params,
+  });
+};

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -78,11 +78,11 @@ const CarSearch = () => {
       count: 3,
     })
       .then((response) => {
-        console.log("불러온 공지사항: ", response.data);
+        console.log("CarDetail / getNoticeList", response.data);
         setNoticeList(response.data);
       })
       .catch((error) => {
-        console.log(error.response);
+        console.log("CarDetail / getNoticeList error", error.response);
       });
   }, [currentRouteKey]);
 

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -16,6 +16,7 @@ import { useLocation, useNavigate } from "react-router";
 import { getPreferOption } from "api/myPageAxios";
 import { useAlert } from "utils/useAlert";
 import { selectedFinderAtom } from "recoil/selectedFinderAtom";
+import { getNoticeList } from "api/carSearchAxios";
 
 const CarSearch = () => {
   // 팝업을 제어하는데 필요한 변수
@@ -38,6 +39,9 @@ const CarSearch = () => {
     transmissions: [true, true],
     minCount: 1,
   });
+
+  // 공지사항 리스트
+  const [noticeList, setNoticeList] = useState(null);
 
   // 검색된 상태의 finder 정보를 가지는 변수
   const selectedFinderInfo = useRecoilValue(selectedFinderAtom);
@@ -65,6 +69,22 @@ const CarSearch = () => {
     newPrefer.minCount = document.getElementById("minCount").value;
     return newPrefer;
   };
+
+  // finder 검색 클릭 시, 공지사항 리스트 불러옴
+  useEffect(() => {
+    getNoticeList({
+      province: selectedFinderInfo.province,
+      store: selectedFinderInfo.store,
+      count: 3,
+    })
+      .then((response) => {
+        console.log("불러온 공지사항: ", response.data);
+        setNoticeList(response.data);
+      })
+      .catch((error) => {
+        console.log(error.response);
+      });
+  }, [currentRouteKey]);
 
   // finder 검색 클릭 시, 선택된 finder 상태로 차량 리스트 조회
   useEffect(() => {
@@ -209,7 +229,9 @@ const CarSearch = () => {
               {/* 어떤 지점 공지사항 */}
               <div className="flex flex-col items-center justify-center my-3">
                 <span>
-                  <span className="font-bold text-blue-600">대구 수성구</span>점
+                  <span className="font-bold text-blue-600">
+                    {`${selectedFinderInfo.province} ${selectedFinderInfo.store} `}
+                  </span>
                   <br />
                 </span>
                 <span className="text-xl font-semibold">공지사항</span>
@@ -217,7 +239,7 @@ const CarSearch = () => {
 
               {/* 공지사항 슬라이더 */}
               <div className="h-[485px]">
-                <NoticeCarousel />
+                <NoticeCarousel noticeList={noticeList} />
               </div>
             </div>
           </div>

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -250,6 +250,7 @@ const CarSearch = () => {
               ? carInfoList.map((v, i) => {
                   return (
                     <div
+                      key={i}
                       onClick={() => {
                         carDetailPopUp.toggle();
                       }}

--- a/src/pages/CarSearch/NoticeCarousel.js
+++ b/src/pages/CarSearch/NoticeCarousel.js
@@ -1,27 +1,7 @@
 import { Carousel } from "@material-tailwind/react";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
-export default function CarouselWithContent() {
-  const dummy = [
-    {
-      image: "https://thecatapi.com/api/images/get?format=src&type=gif",
-      title: "Take a look Take a look",
-      paragragh:
-        "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Tenetur, vitae! Quam nemo, recusandae ipsum ab impedit illo, harum fuga repellendus quo esse quisquam vitae explicabo et ipsa, ut perferendis ducimus.",
-    },
-    {
-      image: "https://thecatapi.com/api/images/get?format=src&type=gif",
-      title: "떼껄룩",
-      paragragh: "카짓은 죽여도 현상금이 걸리지 않는다.",
-    },
-    {
-      image: "https://thecatapi.com/api/images/get?format=src&type=gif",
-      title:
-        "제목이 매우 김 제목이 매우 김 제목이 매우 김 제목이 매우 김 제목이",
-      paragragh:
-        "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Tenetur, vitae! Quam nemo, recusandae ipsum ab impedit illo, harum fuga repellendus quo esse quisquam vitae explicabo et ipsa, ut perferendis ducimus.",
-    },
-  ];
 
+export default function CarouselWithContent({ noticeList }) {
   return (
     <Carousel
       className="select-none rounded-xl shadow-figma"
@@ -31,27 +11,29 @@ export default function CarouselWithContent() {
       autoplay={true}
       loop={true}
     >
-      {dummy.map((v, i) => {
-        return (
-          <div className="relative w-full h-full" key={i}>
-            <div className="absolute inset-0 grid w-full h-full bg-blue-100 place-items-center">
-              <div className="flex flex-col items-center justify-start w-full h-full">
-                <img
-                  className="w-[160px] h-[114px] object-cover mt-[23px] rounded-xl"
-                  src={v.image}
-                  alt=""
-                />
+      {noticeList === null
+        ? null
+        : noticeList.map((v, i) => {
+            return (
+              <div className="relative w-full h-full" key={i}>
+                <div className="absolute inset-0 grid w-full h-full bg-blue-100 place-items-center">
+                  <div className="flex flex-col items-center justify-start w-full h-full">
+                    <img
+                      className="w-[160px] h-[114px] object-cover mt-[23px] rounded-xl"
+                      src="https://thecatapi.com/api/images/get?format=src&type=gif"
+                      alt=""
+                    />
 
-                <h1 className="w-[200px] text-xl font-bold text-center text-blue-900 line-clamp-2 m-4">
-                  {v.title}
-                </h1>
+                    <h1 className="w-[200px] text-xl font-bold text-center text-blue-900 line-clamp-2 m-4">
+                      {v.title}
+                    </h1>
 
-                <p className=" w-[200px] line-clamp-6">{v.paragragh}</p>
+                    <p className=" w-[200px] line-clamp-6">{v.description}</p>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        );
-      })}
+            );
+          })}
     </Carousel>
   );
 }
@@ -82,7 +64,7 @@ function nextArrowCustom({ loop, handleNext, lastIndex }) {
 
 function navigationCustom({ setActiveIndex, activeIndex, length }) {
   return (
-    <div className="absolute z-50 flex gap-2 bottom-10 left-2/4 -translate-x-2/4">
+    <div className="absolute z-40 flex gap-2 bottom-10 left-2/4 -translate-x-2/4">
       {new Array(length).fill("").map((_, i) => (
         <span
           key={i}

--- a/src/pages/CarSearch/NoticeCarousel.js
+++ b/src/pages/CarSearch/NoticeCarousel.js
@@ -1,7 +1,10 @@
 import { Carousel } from "@material-tailwind/react";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
+import { useNavigate } from "react-router-dom";
 
 export default function CarouselWithContent({ noticeList }) {
+  const nav = useNavigate();
+
   return (
     <Carousel
       className="select-none rounded-xl shadow-figma"
@@ -15,7 +18,13 @@ export default function CarouselWithContent({ noticeList }) {
         ? null
         : noticeList.map((v, i) => {
             return (
-              <div className="relative w-full h-full" key={i}>
+              <div
+                className="relative w-full h-full cursor-pointer"
+                key={i}
+                onClick={() => {
+                  nav("/notice", { state: v.noticeId });
+                }}
+              >
                 <div className="absolute inset-0 grid w-full h-full bg-blue-100 place-items-center">
                   <div className="flex flex-col items-center justify-start w-full h-full">
                     <img


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

공지사항이 표시되는 carousel UI 와 서버 api 연결

## 🥥 Contents

### carSearchAxios.js 파일 추가
``` js
import api from "./interceptors";

export const getNoticeList = (payload) => {
  const params = new URLSearchParams();

  params.append("province", payload.province);
  params.append("branchName", payload.store);
  params.append("count", payload.count);

  return api({
    url: "/branches/notices",
    method: "get",
    params: params,
  });
};
```

- 서버에서 원하는 개수만큼 공지사항을 불러오는 api 작성

<br>

### finder 검색을 클릭할 시, 공지사항 리스트를 불러오는 기능 구현

``` js
// finder 검색 클릭 시, 공지사항 리스트 불러옴
useEffect(() => {
  getNoticeList({
    province: selectedFinderInfo.province,
    store: selectedFinderInfo.store,
    count: 3,
  })
    .then((response) => {
      console.log("CarDetail / getNoticeList", response.data);
      setNoticeList(response.data);
    })
    .catch((error) => {
      console.log("CarDetail / getNoticeList error", error.response);
    });
}, [currentRouteKey]);
```

- 종속성 배열에 들어있는 currentRouteKey는 라우터에 대한 고유 키로, CarSearch 페이지에서 finder를 다시 눌렀을 경우에 업데이트가 되지 않는 문제를 해결하기 위해서이다.

<br>

### carousel을 클릭할 시 공지사항을 확인할 수 있도록 구현

``` js
<div
  className="relative w-full h-full cursor-pointer"
  key={i}
  onClick={() => {
    nav("/notice", { state: v.noticeId });
  }}
>
```

- useNavigate 를 사용하여 받은 nav변수와 state 옵션을 사용하여 /notice 라우터로 정보를 전달함

<br>

### 공지사항이 어떤 지점의 것인지 표시

``` js
<span className="font-bold text-blue-600">
  {`${selectedFinderInfo.province} ${selectedFinderInfo.store} `}
</span>
```

- 이전에 만들었던 finder의 특정 시점을 저장하는 selectedFinderAtom을 사용하여 어떤 지점의 공지사항인지 표시함
- selectedFinderAtom은 finder가 검색 버튼이 눌린 시점을 저장하기 때문에 사용자가 CarSearch 페이지를 둘러보다 finder를 변경해도 변경되지 않음

<br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] carousel을 클릭할 경우 notice로 이동한다.
- [x] CarSearch 페이지에 진입할 경우 notice를 받아온다.
- [x] CarSearch 페이지에서 finder를 다시 눌렀을 경우에도 다시 notice를 받아온다.

<br>

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### finder로 지점 진입시 공지사항 표시
![NoticeQuery](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/dd3547cc-eb81-4d3d-a9f0-04a2cf730611)

### CarSearch 화면에서 다시 finder로 검색했을 경우 다시 공지사항 가져오기
![noticeReQuery](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/0787ceb0-63d9-4c9d-ba44-70b937774534)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

<br>

## ⚓ Related Issue

- #100 

close #100 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
