### PR TITLE
[Feat/#102] 차량 상세정보 조회 팝업 api 연결

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Feat/#102-car-popup-api
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Feat/#102-car-popup-api
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/api/carSearchAxios.js
+++ b/src/api/carSearchAxios.js
@@ -13,3 +13,15 @@ export const getNoticeList = (payload) => {
     params: params,
   });
 };
+
+export const getCarDetail = (payload) => {
+  const params = new URLSearchParams();
+
+  params.append("carNumber", payload.carNumber);
+
+  return api({
+    url: "/branches/cars/details",
+    method: "get",
+    params: params,
+  });
+};

--- a/src/components/CarCard.js
+++ b/src/components/CarCard.js
@@ -1,9 +1,14 @@
-import Car from "assets/Car.png";
-import { useRecoilValue } from "recoil";
-import { carAtom } from "recoil/carAtom";
 import { Chip } from "@material-tailwind/react";
 
-const CarCard = ({ name, number, odo, price, imageURI, discountRatio }) => {
+const CarCard = ({
+  name,
+  number,
+  totalDistance,
+  beforePrice,
+  afterPrice,
+  imageURI,
+  discountRatio,
+}) => {
   return (
     <div className="w-[270px] h-[376px] rounded-2xl bg-white mt-8 hover:shadow-figma mx-auto border-2">
       {/* 차량 사진 */}
@@ -24,11 +29,11 @@ const CarCard = ({ name, number, odo, price, imageURI, discountRatio }) => {
           className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-400"
         />
         <Chip
-          value={`# ${odo}km`}
+          value={`# ${totalDistance}km`}
           className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-300 text-blue-900"
         />
         <Chip
-          value={`# ${price / 10000}만원대`}
+          value={`# ${afterPrice / 10000}만원대`}
           className="text-[13px] font-semibold w-[88px] h-[22px] flex justify-center items-center rounded-[5px] m-1 bg-blue-200 text-blue-900"
         />
       </div>
@@ -36,12 +41,10 @@ const CarCard = ({ name, number, odo, price, imageURI, discountRatio }) => {
       <div className="pl-4 mt-4 text-2xl font-extrabold">{name}</div>
       {/* 차량 가격 */}
       <div className="pl-4 mt-4 text-xl font-bold">
-        <span className="line-through text-slate-500">{`₩${
-          price * (1.0 + discountRatio / 100)
-        }`}</span>
-        <span className="ml-2 text-red-500">{-`${discountRatio}%`}</span>
+        <span className="line-through text-slate-500">{`₩${beforePrice}`}</span>
+        <span className="ml-2 text-red-500">{`-${discountRatio}%`}</span>
       </div>
-      <div className="flex justify-end pr-4 mt-2 font-extrabold text-[28px] text-blue-500">{`₩${price}`}</div>
+      <div className="flex justify-end pr-4 mt-2 font-extrabold text-[28px] text-blue-500">{`₩${afterPrice}`}</div>
     </div>
   );
 };

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -53,6 +53,9 @@ const CarSearch = () => {
   // 차량 리스트 렌더링에 필요한 state
   const [carInfoList, setCarInfoList] = useState(null);
 
+  // 차량 상세정보를 확인할때 사용하는 현재 클릭한 차량의 번호
+  const [selectedCarNumber, setSelectedCarNumber] = useState(null);
+
   // 선호차량 검색 체크박스의 변경점을 체크하는 함수
   const gatherInfo = () => {
     let newPrefer = {
@@ -254,6 +257,9 @@ const CarSearch = () => {
                       onClick={() => {
                         carDetailPopUp.toggle();
 
+                        // 팝업에 정보를 넘겨주는 목적으로 state 저장
+                        setSelectedCarNumber(v.carNumber);
+
                         // 로컬스토리지에 없으면 null, 빈 배열로 초기화
                         if (
                           window.localStorage.getItem("resentInquireCar") ===
@@ -319,7 +325,7 @@ const CarSearch = () => {
         <SelectDateTime popUpInfo={dateTimePopUp} />
       ) : undefined}
       {carDetailPopUp.isClicked ? (
-        <CarDetail popUpInfo={carDetailPopUp} />
+        <CarDetail popUpInfo={carDetailPopUp} carNumber={selectedCarNumber} />
       ) : undefined}
     </>
   );

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -297,8 +297,11 @@ const CarSearch = () => {
                       <CarCard
                         name={v.carName}
                         number={v.carNumber}
-                        odo={v.totalDistance}
-                        price={v.price}
+                        totalDistance={v.totalDistance}
+                        beforePrice={v.beforePrice}
+                        afterPrice={v.afterPrice}
+                        imageURI={v.imageUri}
+                        discountRatio={v.discountRatio}
                       ></CarCard>
                     </div>
                   );

--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -7,132 +7,187 @@ import {
   MdSettings,
   MdPeople,
 } from "react-icons/md";
+import { getCarDetail } from "api/carSearchAxios";
+import { selectedFinderAtom } from "recoil/selectedFinderAtom";
+import { useRecoilState } from "recoil";
+import dayjs from "dayjs";
+import { useNavigate } from "react-router-dom";
 
-const CarDetail = ({ popUpInfo, selectedStore, selectedTime }) => {
+const CarDetail = ({ popUpInfo, carNumber }) => {
+  // 예약 페이지로 이동
+  const navigate = useNavigate();
+
   const detailTemplate = [
     {
       title: "주행거리",
+      engTitle: "totalDistance",
       icons: <MdEditRoad />,
+      unit: "km",
     },
     {
       title: "차량 크기",
+      engTitle: "carSize",
       icons: <MdDirectionsCar />,
+      unit: null,
     },
     {
       title: "유종",
+      engTitle: "oilType",
       icons: <MdLocalCarWash />,
+      unit: null,
     },
     {
       title: "구동기",
+      engTitle: "transmission",
       icons: <MdSettings />,
+      unit: null,
     },
     {
       title: "승차인원",
+      engTitle: "maxPassenger",
       icons: <MdPeople />,
+      unit: "인",
     },
   ];
 
-  const dummy = ["50000km", "중형", "전기", "자동", "5인승"];
+  const [carInfo, setCarInfo] = useState(null);
+
+  const [selectedFinderInfo, setSelectedFinderInfo] =
+    useRecoilState(selectedFinderAtom);
+
+  useEffect(() => {
+    getCarDetail({ carNumber: carNumber })
+      .then((response) => {
+        console.log("CarDetail / getCarDetail", response.data);
+        setCarInfo(response.data);
+      })
+      .catch((error) => {
+        console.log("CarDetail / getCarDetail 에러", error.response);
+      });
+  }, []);
 
   return (
     <>
-      {/* 팝업 뒤의 어두운 화면 */}
-      <div className="fixed top-0 left-0 z-40 flex items-center justify-center w-screen h-screen bg-black select-none bg-opacity-40">
-        {/* 팝업 본체 */}
-        <div className="bg-white w-[1050px] h-[640px] rounded-2xl flex justify-center items-center ">
-          <div className="bg-sky-50 w-[1000px] h-[600px] rounded-xl relative flex flex-col items-center justify-around">
-            {/* 닫기 버튼 */}
-            <button
-              className="absolute top-2 left-2"
-              onClick={() => {
-                popUpInfo.toggle();
-              }}
-            >
-              <MdOutlineClose size={49} color="gray" />
-            </button>
+      {/* carInfor가 null로 넘어와 오류를 일으키는 것을 방지 */}
+      {carInfo === null ? null : (
+        // 팝업 뒤의 어두운 화면
+        <div className="fixed top-0 left-0 z-40 flex items-center justify-center w-screen h-screen bg-black select-none bg-opacity-40">
+          {/* 팝업 본체 */}
+          <div className="bg-white w-[1050px] h-[640px] rounded-2xl flex justify-center items-center ">
+            <div className="bg-sky-50 w-[1000px] h-[600px] rounded-xl relative flex flex-col items-center justify-around">
+              {/* 닫기 버튼 */}
+              <button
+                className="absolute top-2 left-2"
+                onClick={() => {
+                  popUpInfo.toggle();
+                }}
+              >
+                <MdOutlineClose size={49} color="gray" />
+              </button>
 
-            <div className="w-[839px] h-[250px] bg-white rounded-xl shadow-figma flex items-center justify-around">
-              {/* 차량 사진 */}
-              <div className="w-[345px] h-[210px] bg-blue-200 rounded-2xl">
-                <img
-                  className="object-fill w-full h-full rounded-2xl"
-                  src="https://thecatapi.com/api/images/get?format=src&type=gif"
-                  alt=""
-                />
-              </div>
-              {/* 차량 설명 */}
-              <div className="w-[345px] h-[210px] flex flex-col items-start">
-                <div>
-                  <div className="font-bold text-[30px]">GRANDEUR HG</div>
-                  <div className="font-semibold text-[24px] text-gray-500 -mt-2">
-                    58부 7792
-                  </div>
+              <div className="w-[839px] h-[250px] bg-white rounded-xl shadow-figma flex items-center justify-around">
+                {/* 차량 사진 */}
+                <div className="w-[345px] h-[210px] bg-blue-200 rounded-2xl">
+                  {/* 일시적인 떼껄룩 */}
+                  <img
+                    className="object-fill w-full h-full rounded-2xl"
+                    src="https://thecatapi.com/api/images/get?format=src&type=gif"
+                    alt=""
+                  />
                 </div>
-                <p className="mt-1">
-                  Lorem Ipsum is simply dummy text of the printing and
-                  typesetting industry. Lorem Ipsum has been the industry's
-                  standard dummy text ever since the 1500s.
-                </p>
-              </div>
-            </div>
-
-            {/* 차량 정보 */}
-            <div className="w-[839px] h-[300px] bg-blue-200 rounded-xl grid grid-cols-3 gap-3 p-3">
-              {/* 차량 특징 */}
-              <div className="grid grid-cols-2 col-span-2 gap-3 p-3 bg-white rounded-xl">
-                {detailTemplate.map((v, i) => {
-                  return (
-                    <div className="flex flex-col items-center justify-center rounded-xl bg-sky-100">
-                      <div className="flex items-center text-[20px] font-semibold self-start px-4">
-                        <span>{v.title}</span>
-                        <span className="ml-4 text-[28px]">{v.icons}</span>
-                      </div>
-                      <div className="text-[24px] font-semibold text-blue-900 self-end px-4">
-                        {dummy[i]}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-              {/* 차량 결제 정보 */}
-              <div className="flex flex-col justify-around col-span-1 px-5 bg-white rounded-xl">
-                <div className="text-[20px] font-semibold text-blue-900 mt-[15px]">
-                  결제정보
-                </div>
-                <div>
-                  <div className="text-[14px] font-medium">대구 수성구점</div>
-                  <div className="text-[20px] font-semibold -mt-2">
-                    9/10 10:00 ~ 9/11 11:00
-                  </div>
-                </div>
-                <div className="flex justify-between mt-2">
+                {/* 차량 설명 */}
+                <div className="w-[345px] h-[210px] flex flex-col items-start">
                   <div>
-                    <div className="text-[16px] font-medium">할인</div>
-                    <div className="-mt-1 font-semibold text-gray-400 line-through text-[20px]">
-                      ₩270000
+                    <div className="font-bold text-[30px]">
+                      {carInfo.carName}
+                    </div>
+                    <div className="font-semibold text-[24px] text-gray-500 -mt-2">
+                      {carInfo.carNumber}
                     </div>
                   </div>
-                  <div className="flex flex-col items-end mt-1">
-                    <div className="text-[12px] font-medium">
-                      성수기 할인 이벤트
+                  <p className="mt-1">{carInfo.carDescription}</p>
+                </div>
+              </div>
+
+              {/* 차량 정보 */}
+              <div className="w-[839px] h-[300px] bg-blue-200 rounded-xl grid grid-cols-3 gap-3 p-3">
+                {/* 차량 특징 */}
+                <div className="grid grid-cols-2 col-span-2 gap-3 p-3 bg-white rounded-xl">
+                  {detailTemplate.map((v, i) => {
+                    return (
+                      <div
+                        className="flex flex-col items-center justify-center rounded-xl bg-sky-100"
+                        key={i}
+                      >
+                        <div className="flex items-center text-[20px] font-semibold self-start px-4">
+                          <span>{v.title}</span>
+                          <span className="ml-4 text-[28px]">{v.icons}</span>
+                        </div>
+                        <div className="text-[24px] font-semibold text-blue-900 self-end px-4">
+                          {`${carInfo[v.engTitle]}${v.unit || ""}`}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                {/* 차량 결제 정보 */}
+                <div className="flex flex-col justify-around col-span-1 px-5 bg-white rounded-xl">
+                  <div className="text-[20px] font-semibold text-blue-900 mt-[15px]">
+                    결제정보
+                  </div>
+                  <div>
+                    <div className="text-[14px] font-medium">{`${selectedFinderInfo.province} ${selectedFinderInfo.store}`}</div>
+                    <div className="text-[19px] font-semibold -mt-2">
+                      {`
+                      ${dayjs(selectedFinderInfo.startDate).format("MM/DD")} 
+                      ${selectedFinderInfo.startTime}
+                      ~
+                      ${dayjs(selectedFinderInfo.endDate).format("MM/DD")}
+                      ${selectedFinderInfo.endTime}`}
                     </div>
-                    <div className="-mt-1 font-semibold text-red-500">-30%</div>
                   </div>
-                </div>
-                <div className="mt-2 ">
-                  <div className="text-[16px] font-medium">예상 결제액</div>
-                  <div className="text-[24px] -mt-1 font-semibold text-blue-500">
-                    ₩200000
+                  <div className="flex justify-between mt-2">
+                    <div>
+                      <div className="text-[14px] font-medium">할인</div>
+                      <div className="-mt-1 font-semibold text-gray-400 line-through text-[20px]">
+                        ₩{`${carInfo.beforePrice}`}
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-end mt-1">
+                      <div className="text-[12px] font-medium">
+                        {carInfo.discountReason}
+                      </div>
+                      <div className="-mt-1 font-semibold text-red-500">
+                        {`-${carInfo.discountRate}%`}
+                      </div>
+                    </div>
                   </div>
+                  <div className="mt-2 ">
+                    <div className="text-[16px] font-medium">예상 결제액</div>
+                    <div className="text-[24px] -mt-1 font-semibold text-blue-500">
+                      ₩{carInfo.afterPrice}
+                    </div>
+                  </div>
+                  <button
+                    className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] -mr-2"
+                    onClick={() => {
+                      navigate("/reservation", {
+                        state: {
+                          carNumber: carNumber,
+                          province: selectedFinderInfo.province,
+                          store: selectedFinderInfo.store,
+                        },
+                      });
+                    }}
+                  >
+                    예약하기
+                  </button>
                 </div>
-                <button className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] -mr-2">
-                  예약하기
-                </button>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

1. 원래 보이지 않았던 차량 카드의 할인 이전 가격, 할인율, 할인 이후 가격을 서버에서 받아와 연결
2. 차량 상세정보 팝업 내부에서의 UI 표현
3. 차량 상세정보 팝업에서 예약 버튼을 클릭 시 정보를 전달과 함께 페이지 이동

## 🥥 Contents

### CarCard 내부에서 props로 데이터를 받아 UI로 보여줌

``` js
const CarCard = ({
  name,
  number,
  totalDistance,
  beforePrice,
  afterPrice,
  imageURI,
  discountRatio,
}) => { ...
```

- 외부에서 정보를 받아와 그대로 보여주는 역할만을 한다.

<br>

### 차량 카드를 클릭하면 상세정보 팝업이 나타나는 기능 추가

``` js
{carDetailPopUp.isClicked ? (
  <CarDetail popUpInfo={carDetailPopUp} carNumber={selectedCarNumber} />
) : undefined}
```

- 선택된 차량의 차량번호를 props를 통해 CarDetail 팝업 내부로 이동시킨다.
- selectedCarNumber의 setter는 차량 카드를 클릭하는 시점에 실행된다.

<br>

### 차량 상세정보에서 useNavigate를 통해 페이지와 정보 이동

``` js
onClick={() => {
  navigate("/reservation", {
    state: {
      carNumber: carNumber,
      province: selectedFinderInfo.province,
      store: selectedFinderInfo.store,
    },
  });
}}
```

- reservation 페이지에서 필요한 carNumber, province, store 정보를 넘겨줌과 동시에 페이지를 이동시킨다.

<br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 차량 리스트 카드에서 챠랑의 정보가 모두 제대로 보여진다.
- [x] 차량 리스트 카드를 클릭하면 차량 상세정보를 표시한다.
- [x] 차량 상세정보 팝업 내부에서 예약하기 버튼을 통해 예약 화면으로 이동할 수 있다.

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 차량 카드를 클릭하면 차량 세부정보를 확인할 수 있음

![CarDetail](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/5968cf72-1c4b-494a-8410-c6672df88036)

<br>

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #102 

close #102 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

<br>

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
