### PR TITLE
[Fix/#115] 닉네임 변경 시 nav의 사용자 정보가 즉시 변경되지 않던 문제를 수정

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#115-nav-name-immediately-change
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#115-nav-name-immediately-change
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,16 +1,18 @@
 import { Link } from "react-router-dom";
 import Logo from "assets/Logo.png";
-import { useEffect, useState, useRef } from "react";
+import { useEffect } from "react";
 import { getUserInfo } from "api/myPageAxios";
+import { useRecoilState } from "recoil";
+import { navNickNameAtom } from "recoil/navNickNameAtom";
 
 const Nav = () => {
-  const [userName, setUserName] = useState(null);
+  const [rclNickName, setRclNickName] = useRecoilState(navNickNameAtom);
 
   useEffect(() => {
     getUserInfo()
       .then((response) => {
         console.log("Nav / 사용자기본정보 : ", response.data);
-        setUserName(response.data.nickname);
+        setRclNickName(response.data.nickname);
       })
       .catch((error) => {
         console.log("Nav / 사용자기본정보 에러", error.response);
@@ -48,7 +50,7 @@ const Nav = () => {
               </Link>
             </div>
             <span className="pr-4 ml-4 text-lg font-bold">
-              <span className="text-amber-400">{userName}</span> 고객님
+              <span className="text-amber-400">{rclNickName}</span> 고객님
               안녕하세요!
             </span>
           </div>

--- a/src/pages/MyPage/UserNickChange.js
+++ b/src/pages/MyPage/UserNickChange.js
@@ -2,12 +2,17 @@ import { useState } from "react";
 import { useAlert } from "utils/useAlert";
 import { Input } from "@material-tailwind/react";
 import { checkNickname, changeNick } from "api/myPageAxios";
+import { useRecoilState } from "recoil";
+import { navNickNameAtom } from "recoil/navNickNameAtom";
 
 /* 닉네임 변경 시 사용할 박스 */
 const UserNickChange = ({ before, userInfo, setUserInfo, changeSetter }) => {
   let [tmpNick, setTmpNick] = useState(""); // 새로 입력된 닉네임
   let [newNick, setNewNick] = useState(""); // 최종적으로 변경할 닉네임
   let [isChekced, setIsChecked] = useState(false); // 중복 검사 여부
+
+  const [rclNavNickName, setRclNavNickName] = useRecoilState(navNickNameAtom);
+
   const alert = useAlert();
   return (
     <div className="w-[1010px] h-40 bg-white rounded-2xl flex items-center px-8 mt-7">
@@ -72,6 +77,7 @@ const UserNickChange = ({ before, userInfo, setUserInfo, changeSetter }) => {
                       console.log("마이페이지 / 닉네임변경 : ", response.data);
                       setUserInfo({ ...userInfo, nickname: newNick });
                       changeSetter(true);
+                      setRclNavNickName(newNick);
                       alert.onAndOff("닉네임이 변경되었습니다.");
                     })
                     .catch((error) =>

--- a/src/recoil/navNickNameAtom.js
+++ b/src/recoil/navNickNameAtom.js
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const navNickNameAtom = atom({
+  key: "navNickNameAtom",
+  default: "",
+});


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

닉네임 변경 시 nav의 사용자 정보가 즉시 변경되지 않던 문제를 수정

## 🥥 Contents

### navNickNameAtom 생성

``` js
import { atom } from "recoil";

export const navNickNameAtom = atom({
  key: "navNickNameAtom",
  default: "",
});
```

- 오직 nav의 닉네임을 표시하기 위한 atom이다.

<br>

### 닉네임 변경 로직 변경

``` js
onClick={async () => {
  if (!isChekced || newNick !== tmpNick) {
    alert.onAndOff("중복 검사가 되지 않았습니다.");
  } else {
    await changeNick(newNick)
      .then((response) => {
        // 닉네임 변경
        console.log("마이페이지 / 닉네임변경 : ", response.data);
        setUserInfo({ ...userInfo, nickname: newNick });
        changeSetter(true);
        setRclNavNickName(newNick);
        alert.onAndOff("닉네임이 변경되었습니다.");
      })
      .catch((error) =>
        console.log(
          "마이페이지 / 닉네임변경에러 : ",
          error.response
        )
      );
  }
}}
```

- 닉네임 변경이 성공한다면 setRclNavNickName을 통해 atom 내용을 수정

<br>

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 닉네임 변경시 nav에 즉시 반영

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

![changeNickName](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/d5200add-4a27-4306-9c33-e3adff7088a8)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #115 

close #115 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
