### PR TITLE
[Feat/#119] 공지사항 api

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Feat/#119-notice-api
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Feat/#119-notice-api
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/api/noticeAxios.js
+++ b/src/api/noticeAxios.js
@@ -1,0 +1,21 @@
+import api from "./interceptors";
+
+/* 공지사항 리스트 */
+let getNoticeList = (params) => {
+  return api({
+    url: "/branches/notices",
+    method: "get",
+    params: params,
+  });
+};
+
+/* 공지사항 조회 */
+let getNotice = (noticeId) => {
+  return api({
+    url: "/branches/notices/details",
+    method: "get",
+    params: { noticeId: noticeId },
+  });
+};
+
+export { getNoticeList, getNotice };

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -75,6 +75,9 @@ const CarSearch = () => {
     return newPrefer;
   };
 
+  // 공지사항 전체 리스트 조회 화면으로 이동
+  const nav = useNavigate();
+
   // finder 검색 클릭 시, 공지사항 리스트 불러옴
   useEffect(() => {
     getNoticeList({
@@ -243,7 +246,18 @@ const CarSearch = () => {
             <div className="w-full">
               {/* 어떤 지점 공지사항 */}
               <Tooltip content="전체 공지사항 보러가기">
-                <button className="flex items-center justify-around w-full h-20 my-3 rounded-2xl bg-sky-50 border-[1px] border-blue-600 px-4 hover:bg-sky-200 hover:shadow-figma">
+                <button
+                  className="flex items-center justify-around w-full h-20 my-3 rounded-2xl bg-sky-50 border-[1px] border-blue-600 px-4 hover:bg-sky-200 hover:shadow-figma"
+                  onClick={() => {
+                    // 공지사항 전체 리스트 조회 화면으로 이동하기 위한 state 정의
+                    nav("/notice", {
+                      state: {
+                        store: selectedFinderInfo.store,
+                        province: selectedFinderInfo.province,
+                      },
+                    });
+                  }}
+                >
                   <div className="flex flex-col items-center justify-around h-full py-8">
                     <span>
                       <span className="font-bold text-blue-600">

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -17,6 +17,8 @@ import { getPreferOption } from "api/myPageAxios";
 import { useAlert } from "utils/useAlert";
 import { selectedFinderAtom } from "recoil/selectedFinderAtom";
 import { getNoticeList } from "api/carSearchAxios";
+import { MdNotificationsActive } from "react-icons/md";
+import { Tooltip } from "@material-tailwind/react";
 
 const CarSearch = () => {
   // 팝업을 제어하는데 필요한 변수
@@ -240,15 +242,20 @@ const CarSearch = () => {
             {/* 공지사항 */}
             <div className="w-full">
               {/* 어떤 지점 공지사항 */}
-              <div className="flex flex-col items-center justify-center my-3">
-                <span>
-                  <span className="font-bold text-blue-600">
-                    {`${selectedFinderInfo.province} ${selectedFinderInfo.store} `}
-                  </span>
-                  <br />
-                </span>
-                <span className="text-xl font-semibold">공지사항</span>
-              </div>
+              <Tooltip content="전체 공지사항 보러가기">
+                <button className="flex items-center justify-around w-full h-20 my-3 rounded-2xl bg-sky-50 border-[1px] border-blue-600 px-4 hover:bg-sky-200 hover:shadow-figma">
+                  <div className="flex flex-col items-center justify-around h-full py-8">
+                    <span>
+                      <span className="font-bold text-blue-600">
+                        {`${selectedFinderInfo.province} ${selectedFinderInfo.store} `}
+                      </span>
+                      <br />
+                    </span>
+                    <span className="text-xl font-semibold">전체 공지사항</span>
+                  </div>
+                  <MdNotificationsActive className="text-[45px]" />
+                </button>
+              </Tooltip>
 
               {/* 공지사항 슬라이더 */}
               <div className="h-[485px]">

--- a/src/pages/CarSearch/NoticeCarousel.js
+++ b/src/pages/CarSearch/NoticeCarousel.js
@@ -40,7 +40,7 @@ export default function CarouselWithContent({ noticeList }) {
                     nav("/noticedetail", {
                       state: {
                         province: selectedFinderInfo.province,
-                        branchName: selectedFinderInfo.store,
+                        store: selectedFinderInfo.store,
                         noticeId: v.noticeId,
                       },
                     });

--- a/src/pages/CarSearch/NoticeCarousel.js
+++ b/src/pages/CarSearch/NoticeCarousel.js
@@ -1,9 +1,12 @@
 import { Carousel } from "@material-tailwind/react";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { selectedFinderAtom } from "recoil/selectedFinderAtom";
 
 export default function CarouselWithContent({ noticeList }) {
   const nav = useNavigate();
+  const selectedFinderInfo = useRecoilValue(selectedFinderAtom);
 
   return (
     <Carousel
@@ -34,7 +37,13 @@ export default function CarouselWithContent({ noticeList }) {
                   className="relative w-full h-full cursor-pointer"
                   key={i}
                   onClick={() => {
-                    nav("/notice", { state: v.noticeId });
+                    nav("/noticedetail", {
+                      state: {
+                        province: selectedFinderInfo.province,
+                        branchName: selectedFinderInfo.store,
+                        noticeId: v.noticeId,
+                      },
+                    });
                   }}
                 >
                   <div className="absolute inset-0 grid w-full h-full bg-blue-100 place-items-center">

--- a/src/pages/Notice/Notice.js
+++ b/src/pages/Notice/Notice.js
@@ -11,7 +11,7 @@ const Notice = () => {
   useEffect(() => {
     const params = {
       province: location.state.province,
-      branchName: location.state.branchName,
+      branchName: location.state.store,
       count: 0,
     };
     getNoticeList(params) // 리스트 조회

--- a/src/pages/Notice/Notice.js
+++ b/src/pages/Notice/Notice.js
@@ -1,18 +1,39 @@
 import NoticeCard from "./NoticeCard";
-import { noticeAtom } from "recoil/noticeAtom";
-import { useRecoilValue } from "recoil";
-import { finderAtom } from "recoil/finderAtom";
 import { MdOutlineArrowBack } from "react-icons/md";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { getNoticeList } from "api/noticeAxios";
 
 const Notice = () => {
-  const notices = useRecoilValue(noticeAtom); // 공지사항 정보
-  const finderInfo = useRecoilValue(finderAtom); // 지점, 날짜, 시간 정보
+  const location = useLocation(); // location state 제어
+  const nav = useNavigate(); // nav 제어
+  const [notices, setNotices] = useState([]); // 공지사항 정보
+  useEffect(() => {
+    const params = {
+      province: location.state.province,
+      branchName: location.state.branchName,
+      count: 0,
+    };
+    getNoticeList(params) // 리스트 조회
+      .then((response) => {
+        console.log("공지사항 / 리스트조회 : ", response.data);
+        setNotices(response.data);
+      })
+      .catch((error) =>
+        console.log("공지사항 / 리스트조회에러 : ", error.response)
+      );
+  }, []);
   return (
     <>
       <div className="w-[1140px] mx-auto mt-[120px]">
         {/* 뒤로 가기 */}
         <div className="flex">
-          <MdOutlineArrowBack className="text-4xl font-bold text-black" />
+          <MdOutlineArrowBack
+            className="text-4xl font-bold text-black"
+            onClick={() => {
+              nav("/carsearch");
+            }}
+          />
           <span className="ml-4 text-4xl font-bold text-indigo-900">
             뒤로 가기
           </span>
@@ -20,12 +41,12 @@ const Notice = () => {
         {/* 지점 */}
         <p className="text-[40px] font-extrabold mt-10">공지사항</p>
         <p className="text-[30px] font-bold text-blue-600 mt-4">
-          {finderInfo.store}
+          {location.state.store}
         </p>
         {/* 공지사항 리스트 */}
         <div className="grid w-full grid-cols-3 mt-4 gap-y-4">
           {notices.map((v, i) => {
-            return <NoticeCard key={i} noticeInfo={v} />;
+            return <NoticeCard key={i} noticeInfo={v} index={i} />;
           })}
         </div>
       </div>

--- a/src/pages/Notice/NoticeCard.js
+++ b/src/pages/Notice/NoticeCard.js
@@ -18,7 +18,7 @@ const NoticeCard = ({ noticeInfo, index }) => {
       nav("/noticedetail", {
         state: {
           province: selectedFinderInfo.province,
-          branchName: selectedFinderInfo.store,
+          store: selectedFinderInfo.store,
           noticeId: noticeInfo.noticeId,
         },
       });

--- a/src/pages/Notice/NoticeCard.js
+++ b/src/pages/Notice/NoticeCard.js
@@ -1,13 +1,34 @@
 import dayjs from "dayjs";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { selectedFinderAtom } from "recoil/selectedFinderAtom";
 
-const NoticeCard = ({ noticeInfo }) => {
+const NoticeCard = ({ noticeInfo, index }) => {
+  const nav = useNavigate(); // nav 제어
+  const selectedFinderInfo = useRecoilValue(selectedFinderAtom); // 시/도 지점 정보
   // 남은 날짜 계산
   const [leftDate, setLeftDate] = useState(
-    dayjs().diff(dayjs(noticeInfo.endDate), "day")
+    dayjs(noticeInfo.finishDate).diff(dayjs(new Date()), "day")
   );
+  // 각 카드마다 onclick 추가
+  useEffect(() => {
+    const card = document.getElementById(`notice${index}`);
+    card.addEventListener("click", () => {
+      nav("/noticedetail", {
+        state: {
+          province: selectedFinderInfo.province,
+          branchName: selectedFinderInfo.store,
+          noticeId: noticeInfo.noticeId,
+        },
+      });
+    });
+  }, []);
   return (
-    <div className="w-[360px] h-[600px] rounded-2xl bg-white border-2 hover:shadow-figma">
+    <div
+      id={`notice${index}`}
+      className="w-[360px] h-[600px] rounded-2xl bg-white border-2 hover:shadow-figma"
+    >
       {/* 공지사항 배너 -> 사진 */}
       <div className="w-full h-[380px] rounded-t-2xl bg-sky-200 flex justify-center items-center">
         공지사항 배너
@@ -19,15 +40,24 @@ const NoticeCard = ({ noticeInfo }) => {
         </span>
         {/* 공지사항 본문 */}
         <p className="text-xl font-semibold line-clamp-3">
-          {noticeInfo.content}
+          {noticeInfo.description}
         </p>
         <div className="flex items-center justify-between w-full">
           {/* 이벤트 기간, 업데이트 날짜 */}
           <span className="text-sm font-medium text-gray-600">
-            {dayjs(noticeInfo.startDate).format("YY년 MM월 DD일")} ~{" "}
-            {dayjs(noticeInfo.endDate).format("YY년 MM월 DD일")}
+            {noticeInfo.startDate === null && noticeInfo.finishDate === null
+              ? ""
+              : `${
+                  noticeInfo.startDate === null
+                    ? ""
+                    : dayjs(noticeInfo.startDate).format("YY년 MM월 DD일")
+                } ~ ${
+                  noticeInfo.finishDate === null
+                    ? ""
+                    : dayjs(noticeInfo.finishDate).format("YY년 MM월 DD일")
+                }`}
             <br />
-            최종 작성일 {dayjs(noticeInfo.recentEdit).format("YY년 MM월 DD일")}
+            최종 작성일 {dayjs(noticeInfo.modifiedAt).format("YY년 MM월 DD일")}
           </span>
           {/* 디데이 계산 */}
           <span className="text-2xl font-bold text-red-500">

--- a/src/pages/NoticeDetail/NoticeDetail.js
+++ b/src/pages/NoticeDetail/NoticeDetail.js
@@ -36,7 +36,7 @@ const NoticeDetail = () => {
               nav("/notice", {
                 state: {
                   province: selectedFinderInfo.province,
-                  branchName: selectedFinderInfo.store,
+                  store: selectedFinderInfo.store,
                 },
               });
             }}
@@ -52,7 +52,7 @@ const NoticeDetail = () => {
           </span>
           {/* 지점 */}
           <span className="text-3xl font-bold text-blue-600">
-            {`${location.state.province}  ${location.state.branchName}`}
+            {`${location.state.province}  ${location.state.store}`}
           </span>
           {/* 이벤트 기간 & 디데이 */}
           <span className="text-3xl font-semibold text-gray-600">


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
- 공지사항 리스트 페이지로 이동하기 위한 버튼 UI 구현
- 공지사항 리스트 api 구현
- 공지사항 상세보기 api 구현
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 공지사항 리스트 페이지 이동 버튼
```javascript
// CarSearch.js
{/* 어떤 지점 공지사항 */}
<Tooltip content="전체 공지사항 보러가기">
  <button
    ... 
    onClick={() => {
      // 공지사항 전체 리스트 조회 화면으로 이동하기 위한 state 정의
      nav("/notice", {
        state: {
          store: selectedFinderInfo.store,
          province: selectedFinderInfo.province,
        },
      });
    }}
  >
```
기존에는 공지사항 리스트 페이지로 넘어가는 트리거가 존재하지 않았다. 그래서 CarSearch 페이지에서 기존에 지점의 공지사항 정보를 보여주던 영역을 버튼으로 바꾸어 공지사항 리스트 페이지로 넘어갈 수 있도록 하였다. 이때, 지점(store)과 시/도(province) 정보를 같이 넘겨주어야 한다.
<br>

### 공지사항 리스트
```javascript
// Notice.js
useEffect(() => {
  const params = {
    province: location.state.province,
    branchName: location.state.store,
    count: 0,
  };
  getNoticeList(params) // 리스트 조회
    .then((response) => {
      setNotices(response.data);
    })
}, []);
```
공지사항 리스트 페이지로 넘어오면 우선 nav 를 통해 전달한 정보들을 location 으로 받게 된다. 그리고 서버로부터 지점의 공지사항 리스트를 전부 받아오게 된다.
```javascript
// Notice.js
{/* 뒤로 가기 */}
<div className="flex">
  <MdOutlineArrowBack
    className="text-4xl font-bold text-black"
    onClick={() => {
      nav("/carsearch");
    }}
  />
  ...
```
CarSearch 에서 Notice 로 이동했기 때문에 반대로 CarSearch 로 이동할 수 있도록 뒤로 가기 버튼이 존재하며 이 때에는 추가적인 state 전달은 필요 없다.
<br>

### 공지사항 상세보기
공지사항 상세보기 페이지로 이동하는 경로는 두 가지이다.
```javascript
// NoticeCarousel.js
onClick={() => {
  nav("/noticedetail", {
    state: {
      province: selectedFinderInfo.province,
      store: selectedFinderInfo.store,
      noticeId: v.noticeId,
    },
  });
}}
```
첫 번째 경로는 CarSearch 에서 해당 지점의 최대 3개의 공지사항을 보여주는 NoticeCarousel 이다. 3개 중 특정 공지사항이 클릭되면 해당 공지사항의 상세보기 페이지로 넘어가게된다. 공지사항 상세보기는 지점, 시/도, 공지사항Id 값을 보내게 된다.
```javascript
// NoticeCard.js
useEffect(() => {
  const card = document.getElementById(`notice${index}`);
  card.addEventListener("click", () => {
    nav("/noticedetail", {
      state: {
        province: selectedFinderInfo.province,
        store: selectedFinderInfo.store,
        noticeId: noticeInfo.noticeId,
      },
    });
  });
}, []);
```
두 번째 경로는 Notice 에서 특정 NoticeCard 를 클릭했을 때이다. 특정 NoticeCard 가 클릭되면 NoticeCarousel 과 똑같이 정보를 담아 이동하게 된다.
```javascript
// NoticeDetail.js
useEffect(() => {
  // 공지사항 조회
  getNotice(location.state.noticeId)
    .then((response) => {
      console.log("공지사항 / 조회 : ", response.data);
      setNoticeInfo(response.data);
    })
}, []);
...
nav("/notice", {
  state: {
    province: selectedFinderInfo.province,
    store: selectedFinderInfo.store,
  },
});
```
공지사항 상세보기는 CarSearch 또는 NoticeCard 에서 받아온 noticeId 값을 이용해 서버로부터 해당 공지사항의 정보를 받아오게 된다.
공지사항 상세보기에서는 뒤로가기 버튼이 아닌 리스트로 돌아가기 버튼으로 Notice 로 이동하게 되는데 Notice 는 지점, 시/도 정보가 필요하기에 담아서 이동해야한다.
<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] CarSearch 에서 버튼 -> Notice -> 특정 공지사항 클릭 -> NoticeDetail -> Notice
- [x] CarSearch-NoticeCarousel -> NoticeDetail -> Notice 

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 공지사항 리스트 & 공지사항 상세보기
![noticetest1_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/1541692f-8328-47f9-808f-8b267d6b2f02)
<br>

### NoticeCarousel & 공지사항 상세보기
![noticetest2_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/e51958d7-e656-41b6-a502-a93b465148ca)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #119 

close #119
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
