### PR TITLE
[Fix/#122] 예약 페이지 더미 데이터들 location state 로 수정

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#122-reservation-location-state-link
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#122-reservation-location-state-link
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/pages/Reservation/Accident.js
+++ b/src/pages/Reservation/Accident.js
@@ -1,5 +1,6 @@
 import { getCarAccident } from "api/reservationAxios";
 import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import {
   Accordion,
   AccordionHeader,
@@ -8,11 +9,12 @@ import {
 import dayjs from "dayjs";
 
 const Accident = () => {
+  const location = useLocation(); // location state 제어
   const [accident, setAccident] = useState([]); // 차량 사고 정보
   const [open, setOpen] = useState(1); // 아코디언 제어
   const handleOpen = (value) => setOpen(open === value ? 0 : value); // 아코디언 on/off
   useEffect(() => {
-    getCarAccident("99가9999") // 차량 사고 내역
+    getCarAccident(location.state.carNumber) // 차량 사고 내역
       .then((response) => {
         console.log("예약 / 사고 : ", response.data);
         setAccident([...response.data]);

--- a/src/pages/Reservation/DefaultInfo.js
+++ b/src/pages/Reservation/DefaultInfo.js
@@ -16,7 +16,7 @@ import Car from "assets/Car.png";
 import dayjs from "dayjs";
 
 const DefaultInfo = () => {
-  const location = useLocation(); // 받아온 props 받기 위함
+  const location = useLocation(); // location state 제어
   const [carInfo, setCarInfo] = useState({}); // 차량 정보
   const [rentInfo, setRentInfo] = useRecoilState(rentInfoSelector); // 최종 결제 시 필요 정보 저장
   const dateInfo = useRecoilValue(selectedFinderAtom); // 예약 기간
@@ -30,8 +30,7 @@ const DefaultInfo = () => {
     <MdOutlineArticle className="ml-4 text-[26px] text-blue-600" />,
   ]);
   useEffect(() => {
-    // location.state
-    getCarInfo("99가9999") // 차량 기본 정보
+    getCarInfo(location.state.carNumber) // 차량 기본 정보
       .then((response) => {
         console.log("예약 / 기본정보 : ", response.data);
         // 데이터 가공

--- a/src/pages/Reservation/DetailInfo.js
+++ b/src/pages/Reservation/DetailInfo.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { getCarInfo } from "api/reservationAxios";
+import { useLocation } from "react-router-dom";
 import {
   MdLocalCarWash,
   MdOutlineDateRange,
@@ -13,6 +14,7 @@ import {
 import dayjs from "dayjs";
 
 const DetailInfo = () => {
+  const location = useLocation(); // location state 제어
   const [carInfo, setCarInfo] = useState({}); // 차량 정보
   const [iconList, setIconList] = useState([
     // 아이콘
@@ -26,7 +28,7 @@ const DetailInfo = () => {
     <MdOutlineFlag className="text-[60px]" />,
   ]);
   useEffect(() => {
-    getCarInfo("99가9999") // 차량 정보 조회
+    getCarInfo(location.state.carNumber) // 차량 정보 조회
       .then((response) => {
         console.log("예약 / 상세정보 : ", response.data);
         // 데이터 가공

--- a/src/pages/Reservation/Map.js
+++ b/src/pages/Reservation/Map.js
@@ -3,11 +3,14 @@ import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 const Map = () => {
-  const location = useLocation();
+  const location = useLocation(); // location state 제어
   const [mapPoint, setMapPoint] = useState({});
   useEffect(() => {
     // location.state
-    getMapPoint({ province: "경상북도", store: "IT관점" })
+    getMapPoint({
+      province: location.state.province,
+      store: location.state.store,
+    })
       .then((response) => {
         console.log("예약 / 지도 : ", response.data);
         // 데이터 가공

--- a/src/pages/Reservation/Repair.js
+++ b/src/pages/Reservation/Repair.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { getCarRepair } from "api/reservationAxios";
+import { useLocation } from "react-router-dom";
 import {
   Accordion,
   AccordionHeader,
@@ -8,11 +9,12 @@ import {
 import dayjs from "dayjs";
 
 const Repair = () => {
+  const location = useLocation(); // location state 제어
   const [repair, setRepair] = useState([]); // 차량 수리 내역
   const [open, setOpen] = useState(1); // 아코디언 제어
   const handleOpen = (value) => setOpen(open === value ? 0 : value); // 아코디언 on/off
   useEffect(() => {
-    getCarRepair("99가9999") // 차량 수리 내역
+    getCarRepair(location.state.carNumber) // 차량 수리 내역
       .then((response) => {
         console.log("예약 / 수리 : ", response.data);
         setRepair([...response.data]);


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
예약 페이지에서 사용하던 더미 데이터들을 location state 로 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 차량 번호 연결
```javascript
// 차량 기본&상세&수리&사고 정보
const location = useLocation(); // location state 제어
...
정보API(location.state.carNumber)
```
기존엔 더미 데이터인 "99가9999" 가 이제는 location state 로 변경되었다.
<br>

### 지점, 시/도 연결
```javascript
// Map.js
useEffect(() => {
  // location.state
  getMapPoint({
    province: location.state.province,
    store: location.state.store,
  })
```
지점의 위치를 보여주는 지도 역시 location state 에서 지점과 시/도 정보를 받아 위도 경도 값을 서버로부터 받아오게 된다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 변경 후에도 잘 동작하는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #122 

close #122

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
