### PR TITLE
[Fix/#118] 차량 상세정보 블럭 크기가 이상해지는 문제 수정

### DIFF
--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -131,7 +131,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                   })}
                 </div>
                 {/* 차량 결제 정보 */}
-                <div className="flex flex-col justify-around col-span-1 px-5 bg-white rounded-xl">
+                <div className="flex flex-col justify-around col-span-1 pl-5 bg-white rounded-xl">
                   <div className="text-[20px] font-semibold text-blue-900 mt-[15px]">
                     결제정보
                   </div>
@@ -153,7 +153,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                         ₩{`${carInfo.beforePrice}`}
                       </div>
                     </div>
-                    <div className="flex flex-col items-end mt-1">
+                    <div className="flex flex-col items-end pr-5 mt-1">
                       <div className="text-[12px] font-medium">
                         {carInfo.discountReason}
                       </div>
@@ -169,7 +169,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                     </div>
                   </div>
                   <button
-                    className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] -mr-2"
+                    className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] mr-3"
                     onClick={() => {
                       navigate("/reservation", {
                         state: {


### PR DESCRIPTION


<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

시간이 양 옆의 패딩으로 인해 2줄로 변경되어 블럭 크기가 이상해지는 문제가 있었음
레이아웃 조정으로 하여 시간을 한줄로 변경

<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents

### 레이아웃 (css) 수정함

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 시간과 날짜가 1줄로 생성됨

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

![스크린샷 2023-10-15 오전 10 32 46](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/82d06ead-54d8-46e4-85ee-9ffe10760369)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #118 

close #118 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
