### PR TITLE
[Fix/#111] 차량 리스트의 카드가 보이는 것보다 큰 범위가 클릭되는 문제 수정

### DIFF
--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -283,63 +283,65 @@ const CarSearch = () => {
             {carInfoList
               ? carInfoList.map((v, i) => {
                   return (
-                    <div
-                      key={i}
-                      onClick={() => {
-                        carDetailPopUp.toggle();
+                    <div>
+                      <div
+                        key={i}
+                        onClick={() => {
+                          carDetailPopUp.toggle();
 
-                        // 팝업에 정보를 넘겨주는 목적으로 state 저장
-                        setSelectedCarNumber(v.carNumber);
+                          // 팝업에 정보를 넘겨주는 목적으로 state 저장
+                          setSelectedCarNumber(v.carNumber);
 
-                        // 로컬스토리지에 없으면 null, 빈 배열로 초기화
-                        if (
-                          window.localStorage.getItem("resentInquireCar") ===
-                          null
-                        ) {
+                          // 로컬스토리지에 없으면 null, 빈 배열로 초기화
+                          if (
+                            window.localStorage.getItem("resentInquireCar") ===
+                            null
+                          ) {
+                            window.localStorage.setItem(
+                              "resentInquireCar",
+                              JSON.stringify([])
+                            );
+                          }
+
+                          // 역변환하여 우리가 아는 배열로 다시 바꿔온다.
+                          let queue = JSON.parse(
+                            window.localStorage.getItem("resentInquireCar")
+                          );
+
+                          // 같은 차량이 들어갈 수 없음
+                          if (queue.includes(v.carNumber)) {
+                            const idx = queue.findIndex(
+                              (elm) => v.carNumber === elm
+                            );
+                            queue.splice(idx, 1);
+                          }
+
+                          // 이미 6개 있으면 제일 앞을 뺌
+                          if (queue.length === 6) {
+                            queue.shift();
+                          }
+
+                          // 새로운 차 번호를 배열 뒤에 넣는다.
+                          queue.push(v.carNumber);
+
+                          // 로컬 스토리지에 배열을 저장
                           window.localStorage.setItem(
                             "resentInquireCar",
-                            JSON.stringify([])
+                            JSON.stringify(queue)
                           );
-                        }
-
-                        // 역변환하여 우리가 아는 배열로 다시 바꿔온다.
-                        let queue = JSON.parse(
-                          window.localStorage.getItem("resentInquireCar")
-                        );
-
-                        // 같은 차량이 들어갈 수 없음
-                        if (queue.includes(v.carNumber)) {
-                          const idx = queue.findIndex(
-                            (elm) => v.carNumber === elm
-                          );
-                          queue.splice(idx, 1);
-                        }
-
-                        // 이미 6개 있으면 제일 앞을 뺌
-                        if (queue.length === 6) {
-                          queue.shift();
-                        }
-
-                        // 새로운 차 번호를 배열 뒤에 넣는다.
-                        queue.push(v.carNumber);
-
-                        // 로컬 스토리지에 배열을 저장
-                        window.localStorage.setItem(
-                          "resentInquireCar",
-                          JSON.stringify(queue)
-                        );
-                      }}
-                    >
-                      {/* 추후 빠진 props 추가할 것 */}
-                      <CarCard
-                        name={v.carName}
-                        number={v.carNumber}
-                        totalDistance={v.totalDistance}
-                        beforePrice={v.beforePrice}
-                        afterPrice={v.afterPrice}
-                        imageURI={v.imageUri}
-                        discountRatio={v.discountRatio}
-                      ></CarCard>
+                        }}
+                      >
+                        {/* 추후 빠진 props 추가할 것 */}
+                        <CarCard
+                          name={v.carName}
+                          number={v.carNumber}
+                          totalDistance={v.totalDistance}
+                          beforePrice={v.beforePrice}
+                          afterPrice={v.afterPrice}
+                          imageURI={v.imageUri}
+                          discountRatio={v.discountRatio}
+                        ></CarCard>
+                      </div>
                     </div>
                   );
                 })


### PR DESCRIPTION


<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

차량 리스트의 카드가 보이는 것보다 큰 범위가 클릭되는 문제 수정

## 🥥 Contents

### 차량 리스트의 카드가 보이는 것보다 큰 범위가 클릭되는 문제 수정
``` js
return (
  <div>
    <div
      key={i}
      onClick={() => {
      }}
    >
      {/* 추후 빠진 props 추가할 것 */}
      <CarCard
        name={v.carName}
        number={v.carNumber}
        totalDistance={v.totalDistance}
        beforePrice={v.beforePrice}
        afterPrice={v.afterPrice}
        imageURI={v.imageUri}
        discountRatio={v.discountRatio}
      ></CarCard>
    </div>
  </div>
```

- div 내부에 다시 div를 감싸 간단하게 해결

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 차량 카드가 보이는 부분만큼만 클릭됨

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 클릭 범위를 다음과 같이 수정

![스크린샷 2023-10-15 오전 10 56 04](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/881893ed-0846-48fc-8d3f-56d1d8ba32b7)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #111 

close #111 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
