### PR TITLE
[Fix/#127] 예약 페이지 finder 연결, 새로고침 시 페이지 이동

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#127-resv-finder
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#127-resv-finder
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/App.js
+++ b/src/App.js
@@ -44,6 +44,8 @@ function App() {
             // 로그인 성공 -> 네비게이션바on, 기존에 있던 경로 or home 으로 이동
             setNavState(true);
             if (location.pathname.split("/")[1] === "") nav("/");
+            else if (location.pathname.split("/")[1] === "reservation")
+              nav("/carsearch");
             else nav("/" + location.pathname.split("/")[1]);
           }
         })

--- a/src/pages/Reservation/DefaultInfo.js
+++ b/src/pages/Reservation/DefaultInfo.js
@@ -45,8 +45,8 @@ const DefaultInfo = () => {
         setCarInfo(tmp);
         setRentInfo({
           carNumber: response.data.carNumber,
-          startDate: dayjs(new Date()).format("YYYY. MM. DD. HH:mm"),
-          endDate: dayjs(new Date()).format("YYYY. MM. DD. HH:mm"),
+          startDate: dayjs(dateInfo.startDate).format("YYYY. MM. DD. HH:mm"),
+          endDate: dayjs(dateInfo.endDate).format("YYYY. MM. DD. HH:mm"),
           beforePrice: response.data.beforePrice,
           afterPrice: response.data.afterPrice,
         });


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
- 차량 기본 정보 finder 정보 연결
- 새로고침 시 carsearch 로 이동
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 차량 기본 정보 finder 연결
```javascript
// DefaultInfo.js
const dateInfo = useRecoilValue(selectedFinderAtom); // 예약 기간
...
setRentInfo({
  startDate: dayjs(dateInfo.startDate).format("YYYY. MM. DD. HH:mm"),
  endDate: dayjs(dateInfo.endDate).format("YYYY. MM. DD. HH:mm"),
  ...
});
```
기존에는 더미 데이터로 렌트 기간을 저장했었으나, finder 의 구현이 끝나면서 정보를 담고있는 selectedFinderAtom 을 연결해주었다.
<br>

### 새로고침 시 carsearch 이동
```javascript
// App.js
else if (location.pathname.split("/")[1] === "reservation")
  nav("/carsearch");
```
기존에는 새로고침 시 예약 페이지에 그대로 있었으나 nav 를 통해 받아온 차량 번호가 계속 남아있을 수 없으며 예약 페이지는 본래 특정 트리거가 존재해야 들어올 수 있는 페이지인만큼 트리거가 발생되는 CarSearch 로 이동하도록 하였다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] finder 정보가 연결되었는지 확인
- [x] 새로고침 시 CarSearch 로 이동하는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 페이지 이동
![resvtocarsearch_gif](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/e33171ba-2fbd-4821-ab71-f1c0cae4bbe6)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #127 

close #127

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
