### PR TITLE
[Fix/#129] 예약 화면에서 검색 클릭 시 아무런 정보 없는 cardetail로 가던 오류 수정

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#129-reservation-backspace
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#129-reservation-backspace
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -12,10 +12,14 @@ import { selectedFinderAtom } from "recoil/selectedFinderAtom";
 import { useRecoilState } from "recoil";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
+import { usePopUp } from "utils/usePopUp";
 
 const CarDetail = ({ popUpInfo, carNumber }) => {
   // 예약 페이지로 이동
   const navigate = useNavigate();
+
+  // 팝업 제어를 위한 변수
+  const carDetailPopUp = usePopUp("CarSearch/CarDetail");
 
   const detailTemplate = [
     {
@@ -171,6 +175,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                   <button
                     className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] mr-3"
                     onClick={() => {
+                      carDetailPopUp.toggle();
                       navigate("/reservation", {
                         state: {
                           carNumber: carNumber,


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

예약 화면에서 검색 클릭 시 아무런 정보 없는 cardetail로 가던 오류 수정

## 🥥 Contents

### 예약 버튼을 클릭하면 팝업을 닫는 코드 추가

``` js
// 팝업 제어를 위한 변수
const carDetailPopUp = usePopUp("CarSearch/CarDetail");

<button
  className="..."
  onClick={() => {
    carDetailPopUp.toggle();
    navigate("/reservation", {
      state: {
        ...
      },
    });
  }}
>
  예약하기
</button>
```

- 예약하기 버튼을 누르면 팝업을 먼저 닫고 reservation으로 이동시킨다
- 팝업을 닫을 때 다시 스크롤을 살리는 기능으로 인해서 예약 페이지에서도 스크롤이 가능하게 됨

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 차량 예약 화면에서 finder 검색시 정상적으로 검색 가능

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

![reservationFinder](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/e0aff419-80b6-4f1d-93d2-af0821759365)

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #129 

close #129 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
