### PR TITLE
[Fix/#132] 예약화면에서 리스트 화면으로 넘어갔을때 다른 카드 안눌리는 버그 수정

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#132-reservation-carsearch-popup
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#132-reservation-carsearch-popup
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/pages/CarSearch/CarSearch.js
+++ b/src/pages/CarSearch/CarSearch.js
@@ -287,10 +287,10 @@ const CarSearch = () => {
                       <div
                         key={i}
                         onClick={() => {
-                          carDetailPopUp.toggle();
-
                           // 팝업에 정보를 넘겨주는 목적으로 state 저장
                           setSelectedCarNumber(v.carNumber);
+
+                          carDetailPopUp.toggle();
 
                           // 로컬스토리지에 없으면 null, 빈 배열로 초기화
                           if (

--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -18,9 +18,6 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
   // 예약 페이지로 이동
   const navigate = useNavigate();
 
-  // 팝업 제어를 위한 변수
-  const carDetailPopUp = usePopUp("CarSearch/CarDetail");
-
   const detailTemplate = [
     {
       title: "주행거리",
@@ -175,7 +172,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                   <button
                     className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] mr-3"
                     onClick={() => {
-                      carDetailPopUp.toggle();
+                      popUpInfo.toggle();
                       navigate("/reservation", {
                         state: {
                           carNumber: carNumber,


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

예약화면에서 리스트 화면으로 넘어갔을때 다른 카드 안눌리는 버그 수정

## 🥥 Contents

### setSelectedCarNumber와 popup 제어의 순서 변경
``` js
// 팝업에 정보를 넘겨주는 목적으로 state 저장
setSelectedCarNumber(v.carNumber);
carDetailPopUp.toggle();
```

- 혹시 몰라 순서를 바꾼 것이라 확실하지 않음

### carDetail로 props를 통해 넘어오는 팝업 상태 변경 변수인 popUpInfo를 사용

``` js
// 팝업 제어를 위한 변수
const carDetailPopUp = usePopUp("CarSearch/CarDetail");
```
- 이전 커밋에서는 팝업을 제어하기 위해 props를 사용하지 않고 carDetailPopUp 변수를 따로 선언하였었기 때문에 삭제하였음.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 예약화면에서 리스트 화면으로 넘어갔을때 다른 카드 안눌리는 버그 수정

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

![rereservation](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/a5037e25-f3dd-4f8b-b23e-8f5fe7d9d08c)



<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue

- #132 

close #132 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
