### PR TITLE
[Fix/#130] 선호 옵션, 로컬스토리지 읽는 방식 수정

### DIFF
--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: Fix/#130-prefer-oil-local-check-fix
+    branches: develop
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tempDeploy.yml
+++ b/.github/workflows/tempDeploy.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 on:
   push:
-    branches: develop
+    branches: Fix/#130-prefer-oil-local-check-fix
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/pages/MyPage/Record.js
+++ b/src/pages/MyPage/Record.js
@@ -21,7 +21,7 @@ const Record = () => {
     setNumberList(JSON.parse(localStorage.getItem("resentInquireCar")));
   }, []);
   useEffect(() => {
-    if (numberList.length !== 0) {
+    if (numberList !== null) {
       const tmp = [];
       numberList.forEach((v, i) => {
         getRecent(v) // 저장된 차량 번호 수만큼 상세 정보 조회

--- a/src/recoil/preferOptionAtom.js
+++ b/src/recoil/preferOptionAtom.js
@@ -1,10 +1,10 @@
-const { atom } = require("recoil");
+import { atom } from "recoil";
 
 export const preferOptionAtom = atom({
   key: "preferOptionAtom",
   default: {
     carSizes: ["소형", "준중형", "중형", "대형"],
-    oilTypes: ["휘발유", "경유", "소수", "전기"],
+    oilTypes: ["휘발유", "경유", "수소", "전기"],
     transmissions: ["수동", "자동"],
   },
 });


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
- 소수 -> 수소
- 마이페이지 최근 본 차량 내역 로컬 스토리지 읽는 방식 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 선호 옵션 유종 수정
```javascript
// PreferOptionAtom.js
export const preferOptionAtom = atom({
  key: "preferOptionAtom",
  default: {
    ...
    oilTypes: ["휘발유", "경유", "수소", "전기"],
  },
});
```
<br>

### 로컬스토리지 읽는 방식 수정
```javascript
// Record.js
useEffect(() => {
  if (numberList !== null) {
     ...
```
기존에는 numberList.length !== 0 이었으나 만약 로컬스토리지에 정보가 존재하지 않는다면 배열로 인식하지 않아 length 를 사용할 수 없다. 그래서 null 인지 아닌지를 비교한다.

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 선호 옵션의 유종이 수소로 변경되었는지 확인 

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### CarSearch-선호옵션
![스크린샷 2023-10-15 오후 3 51 05](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/3245cd80-4ad3-41ff-8874-958228da39b3)
<br>

### MyPage-선호옵션
![스크린샷 2023-10-15 오후 3 50 44](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/86611398/a8f67cfa-14ce-4fc0-aa6a-36a7b5eb4cb4)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #130 

close #130 
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
