### PR TITLE
[Fix/#141] 페이지 이동 시 스크롤이 화면 상단에 가도록 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,11 +25,12 @@ function App() {
   let nav = useNavigate(); // 경로 이동
   let location = useLocation(); // 현재 경로 확인용
   const alertState = useRecoilValue(alertAtom).state; // Alert 제어
+
   useEffect(() => {
     (async () => {
       await axios
         .post(
-          "http://be.yurentcar.kro.kr:1234/api/v1/auth/user-info",
+          "http://deploytest.iptime.org:8080/api/v1/auth/user-info",
           {},
           {
             headers: {

--- a/src/api/interceptors.js
+++ b/src/api/interceptors.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 /* axios 기본 세팅 (인스턴스 이름 api) */
 export const api = axios.create({
-  baseURL: "http://be.yurentcar.kro.kr:1234/api/v1",
+  baseURL: "http://deploytest.iptime.org:8080/api/v1",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@material-tailwind/react";
 import { BrowserRouter } from "react-router-dom";
 import { RecoilRoot } from "recoil";
 import { CookiesProvider } from "react-cookie";
+import ScrollToTop from "components/ScrollToTop";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
@@ -16,6 +17,7 @@ root.render(
     <RecoilRoot>
       <BrowserRouter>
         <ThemeProvider>
+          <ScrollToTop />
           <App />
         </ThemeProvider>
       </BrowserRouter>


### PR DESCRIPTION

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

페이지 이동 시 스크롤이 화면 상단으로 가도록 수정

## 🥥 Contents

### ScrollToTop 컴포넌트 작성

``` js
import { useEffect } from "react";
import { useLocation } from "react-router-dom";

export default function ScrollToTop() {
  const { pathname } = useLocation();

  useEffect(() => {
    window.scrollTo(0, 0);
  }, [pathname]);

  return null;
}
```
- 현재 페이지가 변경되면 scroll을 가장 위로 올리는 코드를 컴포넌트화 해둠

<br>

### index.js 에 컴포넌트 추가

``` js
root.render(
  <CookiesProvider>
    <RecoilRoot>
      <BrowserRouter>
        <ThemeProvider>
          <ScrollToTop />
          <App />
        </ThemeProvider>
      </BrowserRouter>
    </RecoilRoot>
  </CookiesProvider>
);
```

<br>

### 부가적으로 interceptors.js를 변경

- 서버의 주소가 바뀌어 수정하였음.

## 🧪 Testing

- [x] 페이지 이동 시 스크롤이 가장 상단으로 올라감

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 페이지 이동 시 스크롤이 화면 상단에 가도록 수정

![scroll1](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/9cc5760a-896c-4f71-9b11-124c03459fc3)

![scroll2](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/f7512fe4-dda4-46d5-87a9-4092cdde1980)


## ⚓ Related Issue

- #141 

close #141 

## 📚 Reference

[페이지 이동 시 스크롤 이동에 대한 블로그 글](https://dazzlynnnn.tistory.com/entry/React-Link%EB%A1%9C-%ED%8E%98%EC%9D%B4%EC%A7%80-%EC%9D%B4%EB%8F%99-%EC%8B%9C-%EB%A7%A8-%EC%9C%84%EB%A1%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4)


<!-- 자신이 참조한 정보의 출처를 적는다. -->
