### PR TITLE
[Fix/#153] 재 예약 방지

### DIFF
--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -13,6 +13,8 @@ import { useRecoilState } from "recoil";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import { usePopUp } from "utils/usePopUp";
+import { getWaitingResvInfo } from "api/myPageAxios";
+import { useAlert } from "utils/useAlert";
 
 const CarDetail = ({ popUpInfo, carNumber }) => {
   // 예약 페이지로 이동
@@ -55,6 +57,8 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
 
   const [selectedFinderInfo, setSelectedFinderInfo] =
     useRecoilState(selectedFinderAtom);
+
+  const alert = useAlert();
 
   useEffect(() => {
     getCarDetail({ carNumber: carNumber })
@@ -171,14 +175,20 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                   <button
                     className="w-[110px] h-[44px] bg-amber-400 rounded-xl font-semibold text-[20px] self-end mb-[10px] mr-3"
                     onClick={() => {
-                      popUpInfo.toggle();
-                      navigate("/reservation", {
-                        state: {
-                          carNumber: carNumber,
-                          province: selectedFinderInfo.province,
-                          store: selectedFinderInfo.store,
-                        },
-                      });
+                      getWaitingResvInfo()
+                        .then((response) => {
+                          popUpInfo.toggle();
+                          navigate("/reservation", {
+                            state: {
+                              carNumber: carNumber,
+                              province: selectedFinderInfo.province,
+                              store: selectedFinderInfo.store,
+                            },
+                          });
+                        })
+                        .catch((error) => {
+                          alert.onAndOff("이미 예약했던 차량이 있습니다.");
+                        });
                     }}
                   >
                     예약하기

--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -177,6 +177,9 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                     onClick={() => {
                       getWaitingResvInfo()
                         .then((response) => {
+                          alert.onAndOff("이미 예약했던 차량이 있습니다.");
+                        })
+                        .catch((error) => {
                           popUpInfo.toggle();
                           navigate("/reservation", {
                             state: {
@@ -185,9 +188,6 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                               store: selectedFinderInfo.store,
                             },
                           });
-                        })
-                        .catch((error) => {
-                          alert.onAndOff("이미 예약했던 차량이 있습니다.");
                         });
                     }}
                   >


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

다시 예약하는 것을 방지

## 🥥 Contents

### 이미 차량 예약 건이 있을 경우에 차량 하나를 더 예약하려고 하면 예약을 막는다.

``` js
<button
  className="..."
  onClick={() => {
    getWaitingResvInfo()
      .then((response) => {
        alert.onAndOff("이미 예약했던 차량이 있습니다.");
      })
      .catch((error) => {
        popUpInfo.toggle();
        navigate("/reservation", {
          state: {
            carNumber: carNumber,
            province: selectedFinderInfo.province,
            store: selectedFinderInfo.store,
          },
        });
      });
  }}
>
  예약하기
</button>
```

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 예약한 차량이 있는 채로 다른 차량 예약 시 예약을 막음

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

계정에 걸려있는 예약이 없어서 다른 컴퓨터로 확인하느라 이미지 없음

## ⚓ Related Issue

- #153 

close #153 

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
