### PR TITLE
[Fix/#156] 예약이 이미 되어있으면 재예약을 막는 기능 수정

### DIFF
--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -177,17 +177,22 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                     onClick={() => {
                       getWaitingResvInfo()
                         .then((response) => {
-                          alert.onAndOff("이미 예약했던 차량이 있습니다.");
+                          if (response.data.trim() === "") {
+                            popUpInfo.toggle();
+                            navigate("/reservation", {
+                              state: {
+                                carNumber: carNumber,
+                                province: selectedFinderInfo.province,
+                                store: selectedFinderInfo.store,
+                              },
+                            });
+                          } else {
+                            alert.onAndOff("이미 예약했던 차량이 있습니다.");
+                            console.log("예약 조회 내역", response.data);
+                          }
                         })
                         .catch((error) => {
-                          popUpInfo.toggle();
-                          navigate("/reservation", {
-                            state: {
-                              carNumber: carNumber,
-                              province: selectedFinderInfo.province,
-                              store: selectedFinderInfo.store,
-                            },
-                          });
+                          console.log("axios error", error);
                         });
                     }}
                   >

--- a/src/popUp/CarSearch/CarDetail.js
+++ b/src/popUp/CarSearch/CarDetail.js
@@ -177,7 +177,7 @@ const CarDetail = ({ popUpInfo, carNumber }) => {
                     onClick={() => {
                       getWaitingResvInfo()
                         .then((response) => {
-                          if (response.data.trim() === "") {
+                          if (response.data === "") {
                             popUpInfo.toggle();
                             navigate("/reservation", {
                               state: {


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

예약이 이미 되어있으면 재예약을 막는 기능 수정

## 🥥 Contents

### 예약이 없을때를 인식하는 코드 수정

``` js
onClick={() => {
  getWaitingResvInfo()
    .then((response) => {
      if (response.data === "") {
        popUpInfo.toggle();
        navigate("/reservation", {
          state: {
            carNumber: carNumber,
            province: selectedFinderInfo.province,
            store: selectedFinderInfo.store,
          },
        });
      } else {
        alert.onAndOff("이미 예약했던 차량이 있습니다.");
        console.log("예약 조회 내역", response.data);
      }
    })
    .catch((error) => {
      console.log("axios error", error);
    });
}}
```

- 예약이 있으면 예약 객체를 받음
- 예약이 없으면 빈 문자열을 받음

- 이러한 API에 맞추어 코드를 수정

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 예약이 이미 되어있으면 재예약을 막는 기능 수정

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 예약이 이미 되어있으면 재예약 방지

![preventrereservation](https://github.com/YU-RentCar/yurentcar-fe-web-v2/assets/54520200/e015f32d-b8d3-428c-92b9-2b9f6085b16b)

## ⚓ Related Issue

- #156 

close #156 

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
